### PR TITLE
Add services for opening and closing of gripper.

### DIFF
--- a/ros2_ws/src/rcdt_franka/CMakeLists.txt
+++ b/ros2_ws/src/rcdt_franka/CMakeLists.txt
@@ -18,8 +18,10 @@ install(
 
 # Install nodes
 install(PROGRAMS
+  nodes/close_gripper_node.py
   nodes/franka_gripper_simulation_node.py
   nodes/joy_to_gripper_node.py
+  nodes/open_gripper_node.py
   nodes/settings_setter_node.py
   DESTINATION lib/${PROJECT_NAME}
 )

--- a/ros2_ws/src/rcdt_franka/launch/franka.launch.py
+++ b/ros2_ws/src/rcdt_franka/launch/franka.launch.py
@@ -127,6 +127,14 @@ def launch_setup(context: LaunchContext) -> None:
         package="rcdt_franka",
         executable="joy_to_gripper_node.py",
     )
+    open_gripper = Node(
+        package="rcdt_franka",
+        executable="open_gripper_node.py",
+    )
+    close_gripper = Node(
+        package="rcdt_franka",
+        executable="close_gripper_node.py",
+    )
 
     skip = LaunchDescriptionEntity()
     return [
@@ -142,6 +150,8 @@ def launch_setup(context: LaunchContext) -> None:
         joy_topic_manager if moveit_mode == "servo" else skip,
         joy_to_twist_franka if moveit_mode == "servo" else skip,
         joy_to_gripper,
+        open_gripper,
+        close_gripper,
     ]
 
 

--- a/ros2_ws/src/rcdt_franka/nodes/close_gripper_node.py
+++ b/ros2_ws/src/rcdt_franka/nodes/close_gripper_node.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Alliander N. V.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionClient
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
+from rclpy import logging
+from franka_msgs.action import Grasp
+from std_srvs.srv import Trigger
+
+ros_logger = logging.get_logger(__name__)
+
+
+class OpenGripper(Node):
+    def __init__(self) -> None:
+        super().__init__("close_gripper")
+
+        cbg_service = MutuallyExclusiveCallbackGroup()
+        self.create_service(
+            Trigger, "close_gripper", self.callback, callback_group=cbg_service
+        )
+
+        cbg_client = MutuallyExclusiveCallbackGroup()
+        self.client = ActionClient(
+            self, Grasp, "/fr3_gripper/grasp", callback_group=cbg_client
+        )
+
+    def callback(
+        self, _request: Trigger.Request, response: Trigger.Response
+    ) -> Trigger.Response:
+        response.success = self.close_gripper()
+        return response
+
+    def close_gripper(self) -> bool:
+        goal = Grasp.Goal()
+        goal.width = 0.0
+        goal.epsilon.inner = goal.epsilon.outer = 0.08
+        goal.force = 100.0
+        goal.speed = 0.03
+
+        if not self.client.wait_for_server(timeout_sec=2):
+            self.get_logger().error("Gripper grasp client not available.")
+            return False
+
+        result: Grasp.Impl.GetResultService.Response = self.client.send_goal(goal)
+        if not result.result.success:
+            self.get_logger().error("Closing gripper did not succeed.")
+        return result.result.success
+
+
+def main(args: str = None) -> None:
+    rclpy.init(args=args)
+    executor = MultiThreadedExecutor()
+    node = OpenGripper()
+    executor.add_node(node)
+
+    try:
+        executor.spin()
+    except KeyboardInterrupt:
+        ros_logger.info("Keyboard interrupt, shutting down.\n")
+    except Exception as e:
+        raise e
+    finally:
+        node.destroy_node()
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_ws/src/rcdt_franka/nodes/open_gripper_node.py
+++ b/ros2_ws/src/rcdt_franka/nodes/open_gripper_node.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Alliander N. V.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionClient
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
+from rclpy import logging
+from franka_msgs.action import Move
+from std_srvs.srv import Trigger
+
+ros_logger = logging.get_logger(__name__)
+
+
+class OpenGripper(Node):
+    def __init__(self) -> None:
+        super().__init__("open_gripper")
+
+        cbg_service = MutuallyExclusiveCallbackGroup()
+        self.create_service(
+            Trigger, "open_gripper", self.callback, callback_group=cbg_service
+        )
+
+        cbg_client = MutuallyExclusiveCallbackGroup()
+        self.client = ActionClient(
+            self, Move, "/fr3_gripper/move", callback_group=cbg_client
+        )
+
+    def callback(
+        self, _request: Trigger.Request, response: Trigger.Response
+    ) -> Trigger.Response:
+        response.success = self.open_gripper()
+        return response
+
+    def open_gripper(self) -> bool:
+        goal = Move.Goal()
+        goal.width = 0.08
+        goal.speed = 0.03
+
+        if not self.client.wait_for_server(timeout_sec=3):
+            self.get_logger().error("Gripper move client not available.")
+            return False
+
+        result: Move.Impl.GetResultService.Response = self.client.send_goal(goal)
+        if not result.result.success:
+            self.get_logger().error("Opening gripper did not succeed.")
+        return result.result.success
+
+
+def main(args: str = None) -> None:
+    rclpy.init(args=args)
+    executor = MultiThreadedExecutor()
+    node = OpenGripper()
+    executor.add_node(node)
+
+    try:
+        executor.spin()
+    except KeyboardInterrupt:
+        ros_logger.info("Keyboard interrupt, shutting down.\n")
+    except Exception as e:
+        raise e
+    finally:
+        node.destroy_node()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Adds two services: one for opening the gripper and one for closing the gripper.
- Adapts the joy_to_gripper_node to use these new services.
- Uses a MultiThreadedExecutor and different callback groups for different services/clients, to avoid deadlock in a neat way, based on https://docs.ros.org/en/foxy/How-To-Guides/Using-callback-groups.html.
- Add a KeyboardInterrupt except when running the node/executor, to avoid error raising when closing cleanly with keyboard interrupt. (This should be implemented for all nodes later).