### PR TITLE
adding templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATES/bug_report.md
+++ b/.github/ISSUE_TEMPLATES/bug_report.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: Alliander N. V.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 ---
 name: Bug Report
 about: Report a reproducible bug

--- a/.github/ISSUE_TEMPLATES/bug_report.md
+++ b/.github/ISSUE_TEMPLATES/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug Report
+about: Report a reproducible bug
+title: "[BUG] <short description>"
+labels: bug
+
+---
+
+## Description
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+1. Go to '...'
+2. Run '...'
+3. Observe '...'
+
+## Expected Behavior
+What you expected to happen instead.
+
+## Additional Context
+Add any other context or screenshots here.

--- a/.github/ISSUE_TEMPLATES/bug_report.md
+++ b/.github/ISSUE_TEMPLATES/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: Report a reproducible bug
-title: "[BUG] <short description>"
+title: "<short description>"
 labels: bug
 
 ---

--- a/.github/ISSUE_TEMPLATES/feature_request.md
+++ b/.github/ISSUE_TEMPLATES/feature_request.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: Alliander N. V.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 ---
 name: Feature Request
 about: Suggest a new idea or improvement

--- a/.github/ISSUE_TEMPLATES/feature_request.md
+++ b/.github/ISSUE_TEMPLATES/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest a new idea or improvement
+title: "<short description>"
+labels: enhancement
+assignees: ''
+
+---
+
+## Summary
+Describe the proposed enhancement.
+
+## Motivation
+Why this feature is useful or necessary.
+
+## Describe Alternatives
+Are there other approaches that were considered?
+
+## Additional Context
+Related issues, links, or references.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: Alliander N. V.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 ## Description
 
 Please include a summary of the changes and the related issue. 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Description
+
+Please include a summary of the changes and the related issue. 
+Mention if this PR is a bug fix, feature addition, or refactor.
+
+Fixes: #<issue_number>
+
+## Checklist
+
+- [ ] I have tested this code on hardware or in simulation (explain below)
+- [ ] I have updated the documentation (if necessary)
+- [ ] Code builds and passes all tests
+
+## Testing
+
+Explain how you tested your changes.
+
+## Additional Notes
+
+Any relevant screenshots, logs, or context.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,15 +11,13 @@ Mention if this PR is a bug fix, feature addition, or refactor.
 
 Fixes: #<issue_number>
 
-## Checklist
-
-- [ ] I have tested this code on hardware or in simulation (explain below)
-- [ ] I have updated the documentation (if necessary)
-- [ ] Code builds and passes all tests
-
 ## Testing
 
 Explain how you tested your changes.
+
+## Documentation
+
+- [ ] I have updated the documentation (if necessary)
 
 ## Additional Notes
 


### PR DESCRIPTION
## Description

This feature addition introduces default templates for GitHub Issues and Pull Requests for improvement of consistency and communication within the project.

it adds two templates for issues (bugs and feature requests) and one for Pull Requests. 

Fixes: #138 

## Checklist

- [x] I have tested this code on hardware or in simulation (explain below)
- [x] I have updated the documentation (if necessary)
- [x] Code builds and passes all tests

## Testing

Currently I cannot test if it works, also with the apache header but I followed the following links: 
[Issue template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/manually-creating-a-single-issue-template-for-your-repository)
[Github PR](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)
[Github PR Examples](https://axolo.co/blog/p/part-3-github-pull-request-template)


## Additional Notes

-