### PR TITLE
Fix sourcing in dockerfiles

### DIFF
--- a/dockerfiles/install_scripts/core_packages.sh
+++ b/dockerfiles/install_scripts/core_packages.sh
@@ -1,3 +1,5 @@
+#!/bin/bash -i
+
 # SPDX-FileCopyrightText: Alliander N. V.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/dockerfiles/install_scripts/dev_packages.sh
+++ b/dockerfiles/install_scripts/dev_packages.sh
@@ -1,3 +1,5 @@
+#!/bin/bash -i
+
 # SPDX-FileCopyrightText: Alliander N. V.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/dockerfiles/install_scripts/franka_ros2.sh
+++ b/dockerfiles/install_scripts/franka_ros2.sh
@@ -1,3 +1,5 @@
+#!/bin/bash -i
+
 # SPDX-FileCopyrightText: Alliander N. V.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -22,7 +24,6 @@ cd /home/$UNAME/franka_ws/src/franka_ros2
 git checkout v0.1.15
 
 cd /home/$UNAME/franka_ws
-. /opt/ros/humble/setup.sh
-. /home/$UNAME/moveit_ws/install/setup.sh
+source /home/$UNAME/.bashrc
 colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-ignore franka_ign_ros2_control
 echo "source /home/$UNAME/franka_ws/install/setup.bash" >>/home/$UNAME/.bashrc

--- a/dockerfiles/install_scripts/gazebo.sh
+++ b/dockerfiles/install_scripts/gazebo.sh
@@ -1,3 +1,5 @@
+#!/bin/bash -i
+
 # SPDX-FileCopyrightText: Alliander N. V.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -24,7 +26,7 @@ git clone https://github.com/ros-controls/gz_ros2_control.git -b humble
 cd gz_ros2_control
 git checkout 0.7.9
 cd /home/$UNAME/control_ws
-. /opt/ros/humble/setup.sh
+source /home/$UNAME/.bashrc
 colcon build
 echo "source /home/$UNAME/control_ws/install/setup.bash" >>/home/$UNAME/.bashrc
 

--- a/dockerfiles/install_scripts/husarion_ugv_ros.sh
+++ b/dockerfiles/install_scripts/husarion_ugv_ros.sh
@@ -1,3 +1,5 @@
+#!/bin/bash -i
+
 # SPDX-FileCopyrightText: Alliander N. V.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -20,6 +22,6 @@ rm -rf src/ros2_controllers
 rosdep update --rosdistro $ROS_DISTRO
 rosdep install --from-paths src -y -i
 
-. /opt/ros/humble/setup.sh
+source /home/$UNAME/.bashrc
 colcon build --packages-up-to panther --cmake-args -DCMAKE_BUILD_TYPE=Release
 echo "source /home/$UNAME/husarion_ws/install/setup.bash" >>/home/$UNAME/.bashrc

--- a/dockerfiles/install_scripts/libfranka.sh
+++ b/dockerfiles/install_scripts/libfranka.sh
@@ -1,3 +1,5 @@
+#!/bin/bash -i
+
 # SPDX-FileCopyrightText: Alliander N. V.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/dockerfiles/install_scripts/moveit.sh
+++ b/dockerfiles/install_scripts/moveit.sh
@@ -1,7 +1,8 @@
+#!/bin/bash -i
+
 # SPDX-FileCopyrightText: Alliander N. V.
 #
 # SPDX-License-Identifier: Apache-2.0
-
 set -e
 
 mkdir -p /home/$UNAME/moveit_ws/src
@@ -15,6 +16,6 @@ for repo in moveit2/moveit2.repos $(
 rosdep install -r --from-paths . --ignore-src --rosdistro $ROS_DISTRO -y
 
 cd /home/$UNAME/moveit_ws
-. /opt/ros/humble/setup.sh
+source /home/$UNAME/.bashrc
 colcon build --event-handlers desktop_notification- status- --cmake-args -DCMAKE_BUILD_TYPE=Release ${COLCON_BUILD_SEQUENTIAL:+--executor sequential}
 echo "source /home/$UNAME/moveit_ws/install/setup.bash" >>/home/$UNAME/.bashrc

--- a/dockerfiles/install_scripts/moveit_tools.sh
+++ b/dockerfiles/install_scripts/moveit_tools.sh
@@ -1,3 +1,5 @@
+#!/bin/bash -i
+
 # SPDX-FileCopyrightText: Alliander N. V.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -22,7 +24,6 @@ cd /home/$UNAME/bio_ik_ws/src
 git clone https://github.com/PickNikRobotics/bio_ik.git -b ros2
 
 cd /home/$UNAME/bio_ik_ws/
-. /opt/ros/humble/setup.sh
-. /home/$UNAME/moveit_ws/install/setup.sh
+source /home/$UNAME/.bashrc
 colcon build
 echo "source /home/$UNAME/bio_ik_ws/install/setup.bash" >>/home/$UNAME/.bashrc

--- a/dockerfiles/install_scripts/panther_ros.sh
+++ b/dockerfiles/install_scripts/panther_ros.sh
@@ -1,3 +1,5 @@
+#!/bin/bash -i
+
 # SPDX-FileCopyrightText: Alliander N. V.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -19,6 +21,6 @@ rm -rf src/ros2_controllers
 rosdep update --rosdistro $ROS_DISTRO
 rosdep install --from-paths src -y -i
 
-. /opt/ros/humble/setup.sh
+source /home/$UNAME/.bashrc
 colcon build --packages-up-to panther --cmake-args -DCMAKE_BUILD_TYPE=Release
 echo "source /home/$UNAME/husarion_ws/install/setup.bash" >>/home/$UNAME/.bashrc

--- a/dockerfiles/install_scripts/pyflow.sh
+++ b/dockerfiles/install_scripts/pyflow.sh
@@ -1,3 +1,5 @@
+#!/bin/bash -i
+
 # SPDX-FileCopyrightText: Alliander N. V.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/dockerfiles/install_scripts/rosboard.sh
+++ b/dockerfiles/install_scripts/rosboard.sh
@@ -1,3 +1,5 @@
+#!/bin/bash -i
+
 # SPDX-FileCopyrightText: Alliander N. V.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -11,6 +13,6 @@ mkdir -p /home/$UNAME/rosboard_ws/src
 cd /home/$UNAME/rosboard_ws
 git clone https://github.com/dheera/rosboard.git src/rosboard
 
-. /opt/ros/humble/setup.sh
+source /home/$UNAME/.bashrc
 colcon build
 echo "source /home/$UNAME/rosboard_ws/install/setup.bash" >>/home/$UNAME/.bashrc

--- a/dockerfiles/install_scripts/sensors.sh
+++ b/dockerfiles/install_scripts/sensors.sh
@@ -1,3 +1,5 @@
+#!/bin/bash -i
+
 # SPDX-FileCopyrightText: Alliander N. V.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/dockerfiles/install_scripts/sphinx.sh
+++ b/dockerfiles/install_scripts/sphinx.sh
@@ -1,3 +1,5 @@
+#!/bin/bash -i
+
 # SPDX-FileCopyrightText: Alliander N. V.
 #
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
## Description

This adds shebangs to all install scripts used by our dockerfile. This enables sourcing of the .bashrc file, since bash is now used. Therefore, packages installed in previous steps are now sourced correctly.

Fixes: #141 

## Testing

Tested by validating that the pipeline can build the docker image correctly and pass our tests.

## Additional Notes

-