### PR TITLE
166 add pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,21 @@
+# SPDX-FileCopyrightText: Alliander N. V.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# To use:
+#
+#     pre-commit run -a
+#
+# Or:
+#
+#     pre-commit install  # (runs every time you commit in git)
+#
+# To update this file:
+#
+#     pre-commit autoupdate
+#
+# See https://github.com/pre-commit/pre-commit
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.10
+    hooks:
+      - id: ruff
+        entry: ruff format  
+        language: system
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.10
+    hooks:
+      - id: ruff
+        entry: ruff check  
+        language: system  
+  - repo: https://github.com/fsfe/reuse-tool
+    rev: v3.0.1
+    hooks:
+      - id: reuse

--- a/dockerfiles/install_scripts/dev_packages.sh
+++ b/dockerfiles/install_scripts/dev_packages.sh
@@ -6,6 +6,8 @@
 
 set -e
 
+pip install pre-commit
+
 # Install pytest-timeout:
 pip install pytest-timeout
 


### PR DESCRIPTION
## Description

This PR creates an initial pre-commit for Reuse and ruff. 
It doesnt fix linting for C++ yet with clang-format. 

Fixes: does not yet fix 166 but is an initial setup.

## Testing

Tested locally with    `pre-commit run --all-files`

## Documentation

- [x] I have updated the documentation (if necessary)

## Additional Notes

You need to run pre-commit install locally to use it. 