### PR TITLE
150 Enforce additional Ruff lint rules and enable docstring checks

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,9 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Global pytest fixtures for ROS 2 integration testing.
-"""
+"""Global pytest fixtures for ROS 2 integration testing."""
 
 from typing import Iterator
 
@@ -15,7 +13,13 @@ from rclpy.node import Node
 
 @pytest.fixture(scope="module")
 def test_node() -> Iterator[Node]:
-    """Fixture to create a singleton node for testing."""
+    """Fixture to create a singleton node for testing.
+
+    This node is used to ensure that the ROS 2 context is initialized and can be used in tests.
+
+    Yields:
+        Node: The singleton node for testing.
+    """
     rclpy.init()
     node = Node("test_node")
     yield node
@@ -25,17 +29,36 @@ def test_node() -> Iterator[Node]:
 
 @pytest.fixture(scope="module")
 def timeout(pytestconfig: pytest.Config) -> int:
-    """Fixture to get the timeout value from pytest config."""
+    """Fixture to get the timeout value from pytest config.
+
+    Args:
+        pytestconfig (pytest.Config): The pytest configuration object.
+
+    Returns:
+        int: The timeout value in seconds.
+    """
     return int(pytestconfig.getini("timeout"))
 
 
 @pytest.fixture(scope="session")
 def finger_joint_fault_tolerance() -> float:
-    """Tolerance of testing finger joint movements."""
+    """Tolerance of testing finger joint movements.
+
+    This is the maximum allowed deviation for finger joint movements during tests.
+
+    Returns:
+        float: The tolerance value for finger joint movements.
+    """
     return 0.025
 
 
 @pytest.fixture(scope="session")
 def joint_movement_tolerance() -> float:
-    """Tolerance of testing joint movements."""
+    """Tolerance of testing joint movements.
+
+    This is the maximum allowed deviation for joint movements during tests.
+
+    Returns:
+        float: The tolerance value for joint movements.
+    """
     return 0.01

--- a/pyflow/packages/RCDT/Core/core.py
+++ b/pyflow/packages/RCDT/Core/core.py
@@ -362,7 +362,7 @@ class Message(PyflowComputer):
         for pin_name in self.pin_manager.get_input_pin_names():
             data = self.pin_manager.get_data(pin_name)
             levels = pin_name.split("/")
-            if levels[0] == "":
+            if not levels[0]:
                 setattr(message, levels[-1], data)
             else:
                 attribute_str = ".".join(levels[:-1])
@@ -409,7 +409,8 @@ class Message(PyflowComputer):
             return
         self.pin_manager.add_input_pin(register_name, pin)
 
-    def get_subfields(self, message_field: MessageField) -> list[MessageField]:
+    @staticmethod
+    def get_subfields(message_field: MessageField) -> list[MessageField]:
         """Get subfields of a message field that are also messages.
 
         Args:

--- a/pyflow/packages/RCDT/Core/core.py
+++ b/pyflow/packages/RCDT/Core/core.py
@@ -19,30 +19,90 @@ logger = getLogger(__name__)
 
 
 class PinManager:
+    """Manage PyFlow node I/O pins.
+
+    Keeps registry of input and output `PinBase` objects for a node,
+    making it easy to look up, add, and retrieve pin values.
+
+    Attributes:
+        input_pins (dict[str, PinBase]): Mapping from pin name to input pin.
+        output_pins (dict[str, PinBase]): Mapping from pin name to output pin.
+    """
+
     def __init__(self):
+        """Initialize the PinManager with empty dictionaries for input and output pins."""
         self.input_pins: dict[str, PinBase] = {}
         self.output_pins: dict[str, PinBase] = {}
 
     def add_input_pin(self, pin_name: str, pin: PinBase) -> None:
+        """Add an input pin to the manager.
+
+        Args:
+            pin_name (str): The name of the pin.
+            pin (PinBase): The pin to be added.
+        """
         self.input_pins[pin_name] = pin
 
     def add_output_pin(self, pin_name: str, pin: PinBase) -> None:
+        """Add an output pin to the manager.
+
+        Args:
+            pin_name (str): The name of the pin.
+            pin (PinBase): The pin to be added.
+        """
         self.output_pins[pin_name] = pin
 
     def get_data(self, pin_name: str) -> object:
+        """Get data from an input pin.
+
+        Args:
+            pin_name (str): The name of the input pin.
+
+        Returns:
+            object: The data from the input pin.
+        """
         return self.input_pins[pin_name].getData()
 
     def set_data(self, pin_name: str, data: object) -> object:
+        """Set data to an output pin.
+
+        Args:
+            pin_name (str): The name of the output pin.
+            data (object): The data to be set.
+
+        Returns:
+            object: The data set to the output pin.
+        """
         return self.output_pins[pin_name].setData(data)
 
     def get_input_pin_names(self) -> list[str]:
+        """Get the names of all input pins.
+
+        Returns:
+            list[str]: A list of input pin names.
+        """
         return list(self.input_pins.keys())
 
     def get_output_pin_names(self) -> list[str]:
+        """Get the names of all output pins.
+
+        Returns:
+            list[str]: A list of output pin names.
+        """
         return list(self.output_pins.keys())
 
 
 class PyflowRosBridge:
+    """Initialize and run a singleton ROS 2 node for PyFlow.
+
+    Creates a global `rclpy` node named "pyflow" and spins it
+    on a background thread so that all PyFlow-based nodes
+    can share one ROS 2 context.
+
+    Attributes:
+        node (rclpy.node.Node): The shared ROS 2 node instance.
+    """
+
     rclpy.init()
     node = Node("pyflow")
     Thread(target=rclpy.spin, args=[node], daemon=True).start()
@@ -50,27 +110,71 @@ class PyflowRosBridge:
 
 
 class PyflowBase(NodeBase):
+    """Base class for PyFlow nodes integrated with ROS 2.
+
+    Extends `NodeBase` to include a `PinManager` for handling
+    the nodes input and output pins.
+
+    Attributes:
+        pin_manager (PinManager): Manager for this nodes pins.
+    """
+
     def __init__(self, name: str):
+        """Initialize the PyFlow node with a name and a PinManager.
+
+        Args:
+            name (str): The name of the node.
+        """
         super().__init__(name)
         self.pin_manager = PinManager()
 
 
 class PyflowComputer(PyflowBase):
+    """Abstract PyFlow node that computes data but does not execute.
+
+    Subclasses must implement `compute()` to perform calculations
+    based on input pins and write results to output pins.
+    """
+
     def compute(self, *_args: any, **_kwargs: any) -> None:
+        """Compute data based on input pins and set output pins."""
         raise NotImplementedError
 
 
 class PyflowExecutor(PyflowBase):
+    """Abstract PyFlow node that executes actions.
+
+    Subclasses must implement `execute()` to perform side-effecting
+    operations (e.g. calling services, publishing topics).
+    """
+
     def execute(self, *_args: any, **_kwargs: any) -> None:
+        """Execute actions based on input pins and perform side effects."""
         raise NotImplementedError
 
 
 class PyflowNonBlockingExecutor(PyflowExecutor):
+    """Executor that runs `execute()` in a background thread.
+
+    Allows the node to respond to incoming signals without blocking
+    the main PyFlow scheduler.
+
+    Attributes:
+        non_blocking_executor_is_active (bool): True if a background
+            execution is currently in progress.
+    """
+
     def __init__(self, name: str):
+        """Initialize the non-blocking executor with a name.
+
+        Args:
+            name (str): The name of the executor.
+        """
         super().__init__(name)
         self.non_blocking_executor_is_active = False
 
     def execute_parallel(self, *_args: any, **_kwargs: any) -> None:
+        """Start the execution in a separate thread if not already active."""
         if self.non_blocking_executor_is_active:
             logger.error("Executor is already working. Rejected.")
             return
@@ -78,13 +182,32 @@ class PyflowNonBlockingExecutor(PyflowExecutor):
         thread.start()
 
     def execution_steps(self) -> None:
+        """Run the execution steps in a separate thread."""
         self.non_blocking_executor_is_active = True
         self.execute()
         self.non_blocking_executor_is_active = False
 
 
 class Service(PyflowNonBlockingExecutor):
+    """PyFlow node for making ROS 2 service calls.
+
+    Dynamically creates input/output pins matching the
+    service’s request/response message fields, then calls
+    the service in a non-blocking manner.
+
+    Attributes:
+        service_type (type): The ROS 2 service type class.
+        service_name (str): Name of the service to call.
+        client (rclpy.client.Client): The ROS 2 service client.
+        exec_out (PinBase): Execution completion pin.
+    """
+
     def __init__(self, name: str):
+        """Initialize the Service node with a name.
+
+        Args:
+            name (str): The name of the service node.
+        """
         super().__init__(name)
         self.service_type: type
         self.service_name: str
@@ -100,6 +223,7 @@ class Service(PyflowNonBlockingExecutor):
         )
 
     def execute(self, *_args: any, **_kwargs: any) -> None:
+        """Execute the service call using input pins to create the request."""
         request = self.create_request_from_pins()
         response = self.call_service(request)
         if not response.success:
@@ -112,6 +236,11 @@ class Service(PyflowNonBlockingExecutor):
         self.exec_out.call()
 
     def create_data_pins(self, service_part: str) -> None:
+        """Create input/output pins for the service request or response.
+
+        Args:
+            service_part (str): Either "Request" or "Response" to specify which part of the service to create pins for.
+        """
         msg_type: type = getattr(self.service_type, service_part)
         fields_and_field_types: dict[str, str] = msg_type.get_fields_and_field_types()
         for field, field_type in fields_and_field_types.items():
@@ -127,6 +256,11 @@ class Service(PyflowNonBlockingExecutor):
                 logger.warning("Message is not a Request or a Response. Skip.")
 
     def create_request_from_pins(self) -> object:
+        """Create a service request object from input pin data.
+
+        Returns:
+            object: An instance of the service request type with data from input pins.
+        """
         request = self.service_type.Request()
         for pin_name in self.pin_manager.get_input_pin_names():
             data = self.pin_manager.get_data(pin_name)
@@ -134,11 +268,24 @@ class Service(PyflowNonBlockingExecutor):
         return request
 
     def set_response_to_pins(self, response: object) -> None:
+        """Set the response data to output pins.
+
+        Args:
+            response (object): The service response object containing data to set to output pins.
+        """
         for pin_name in self.pin_manager.get_output_pin_names():
             data = getattr(response, pin_name)
             self.pin_manager.set_data(pin_name, data)
 
     def call_service(self, request: object) -> object:
+        """Call the ROS 2 service with the given request.
+
+        Args:
+            request (object): The service request object to send.
+
+        Returns:
+            object: The service response object containing the result of the service call.
+        """
         logger.info(f"Calling service {self.service_name}...")
         response = self.service_type.Response()
         response.success = False
@@ -160,11 +307,25 @@ class Service(PyflowNonBlockingExecutor):
 
     @staticmethod
     def category() -> str:
+        """Get the category of the service node.
+
+        Returns:
+            str: The category of the service node.
+        """
         return "Services"
 
 
 @dataclass
 class MessageField:
+    """Data class to represent a field in a ROS 2 message.
+
+    Attributes:
+        data (object): The data of the field, typically an instance of a ROS 2 message type.
+        name (str): The name of the field.
+        parents (str): The hierarchical path of parent fields, used for nested messages.
+        pin_type (str): The type of pin to create for this field, based on its Python type.
+    """
+
     data: object
     name: str = ""
     parents: str = ""
@@ -172,7 +333,21 @@ class MessageField:
 
 
 class Message(PyflowComputer):
+    """PyFlow node for creating ROS 2 message instances.
+
+    Dynamically creates input pins for each field in the message type,
+
+    Atributes:
+        message_type (type): The ROS 2 message type class to instantiate.
+        unique_input_names (list[str]): List of unique names for input pins to avoid conflicts.
+    """
+
     def __init__(self, name: str):
+        """Initialize the Message node with a name.
+
+        Args:
+            name (str): The name of the message node.
+        """
         super().__init__(name)
         self.message_type: type
 
@@ -182,6 +357,7 @@ class Message(PyflowComputer):
         self.create_input_pins()
 
     def compute(self, *_args: any, **_kwargs: any) -> None:
+        """Compute the message by gathering data from input pins and setting it to the output pin."""
         message = self.message_type()
         for pin_name in self.pin_manager.get_input_pin_names():
             data = self.pin_manager.get_data(pin_name)
@@ -196,6 +372,7 @@ class Message(PyflowComputer):
         self.pin_manager.set_data(output_pin, message)
 
     def create_output_pin(self) -> None:
+        """Create an output pin for the message type."""
         pin_name = self.message_type.__name__
         module = self.message_type.__module__
         pin_type = module.split(".")[0] + "/" + pin_name
@@ -203,6 +380,7 @@ class Message(PyflowComputer):
         self.pin_manager.add_output_pin(pin_name, pin)
 
     def create_input_pins(self) -> None:
+        """Create input pins for each field in the message type."""
         message_fields = [MessageField(self.message_type())]
 
         while len(message_fields) > 0:
@@ -213,6 +391,11 @@ class Message(PyflowComputer):
                 self.create_pin_for_basetype(message_field)
 
     def create_pin_for_basetype(self, message_field: MessageField) -> None:
+        """Create an input pin for a basic type field in the message.
+
+        Args:
+            message_field (MessageField): The field to create a pin for, containing data, name, parents, and pin_type.
+        """
         name = message_field.name
         pin_name = self.make_unique(name)
         pin_type = message_field.pin_type
@@ -227,6 +410,14 @@ class Message(PyflowComputer):
         self.pin_manager.add_input_pin(register_name, pin)
 
     def get_subfields(self, message_field: MessageField) -> list[MessageField]:
+        """Get subfields of a message field that are also messages.
+
+        Args:
+            message_field (MessageField): The field to extract subfields from.
+
+        Returns:
+            list[MessageField]: A list of MessageField instances representing subfields.
+        """
         fields_and_field_types: dict[str, str] = (
             message_field.data.get_fields_and_field_types()
         )
@@ -240,6 +431,14 @@ class Message(PyflowComputer):
         return subfields
 
     def make_unique(self, name: str) -> str:
+        """Ensure the pin name is unique by appending spaces if necessary.
+
+        Args:
+            name (str): The base name for the pin.
+
+        Returns:
+            str: A unique name for the pin, ensuring no conflicts with existing names.
+        """
         while name in self.unique_input_names:
             name += " "
         self.unique_input_names.append(name)
@@ -247,10 +446,24 @@ class Message(PyflowComputer):
 
     @staticmethod
     def category() -> None:
+        """Get the category of the message node.
+
+        Returns:
+            str: The category of the message node.
+        """
         return "Messages"
 
 
 def get_pin_type(python_type: str, field_type: str) -> str:
+    """Get the appropriate PyFlow pin type based on the Python type and field type.
+
+    Args:
+        python_type (str): The string representation of the Python type.
+        field_type (str): The ROS 2 field type as a string.
+
+    Returns:
+        str: The PyFlow pin type to use for this field.
+    """
     match python_type:
         case "<class 'bool'>":
             return "BoolPin"

--- a/pyflow/packages/RCDT/Core/definitions.py
+++ b/pyflow/packages/RCDT/Core/definitions.py
@@ -7,6 +7,15 @@ from dataclasses import dataclass
 
 @dataclass
 class ServiceDefinition:
+    """Definition of a service in the RCDT system.
+
+    Attributes:
+        service_name (str): The name of the service.
+        service_type (type): The type of the service, typically a ROS service type.
+        pyflow_name (str): The name of the PyFlow node that implements this service.
+        pyflow_group (str): The group to which the PyFlow node belongs.
+    """
+
     service_name: str
     service_type: type
     pyflow_name: str

--- a/pyflow/packages/RCDT/Core/node_loader.py
+++ b/pyflow/packages/RCDT/Core/node_loader.py
@@ -7,12 +7,28 @@ from RCDT.Core.definitions import ServiceDefinition
 
 
 def get_pyflow_nodes_from_ros_messages(messages: list[type]) -> dict:
+    """Create PyFlow nodes from ROS message types.
+
+    Args:
+        messages (list[type]): A list of ROS message types.
+
+    Returns:
+        dict: A dictionary mapping message names to PyFlow node classes.
+    """
     return {
         message.__name__: create_class_from_message(message) for message in messages
     }
 
 
 def create_class_from_message(message: type) -> type:
+    """Create a PyFlow node class from a ROS message type.
+
+    Args:
+        message (type): The ROS message type to create a PyFlow node for.
+
+    Returns:
+        type: A new class that inherits from `Message`, representing the PyFlow node.
+    """
     return type(
         message.__name__,
         (Message,),
@@ -26,6 +42,14 @@ def create_class_from_message(message: type) -> type:
 def get_pyflow_nodes_from_ros_services(
     service_definitions: list[ServiceDefinition],
 ) -> dict:
+    """Create PyFlow nodes from ROS service definitions.
+
+    Args:
+        service_definitions (list[ServiceDefinition]): A list of service definitions.
+
+    Returns:
+        dict: A dictionary mapping service names to PyFlow node classes.
+    """
     return {
         service_definition.pyflow_name: create_class_from_service(service_definition)
         for service_definition in service_definitions
@@ -33,7 +57,21 @@ def get_pyflow_nodes_from_ros_services(
 
 
 def create_class_from_service(service_definition: ServiceDefinition) -> type:
+    """Create a PyFlow node class from a ROS service definition.
+
+    Args:
+        service_definition (ServiceDefinition): The service definition to create a PyFlow node for.
+
+    Returns:
+        type: A new class that inherits from `Service`, representing the PyFlow node.
+    """
+
     def category() -> str:
+        """Return the category of the service.
+
+        Returns:
+            str: The category of the service.
+        """
         return service_definition.pyflow_group
 
     return type(

--- a/pyflow/packages/RCDT/Core/pin_loader.py
+++ b/pyflow/packages/RCDT/Core/pin_loader.py
@@ -152,7 +152,7 @@ def get_types_from_message(message: type) -> None:
         message_type = type(getattr(message, field))
         if message_type.__name__ in exclude:
             continue
-        if message_type.__name__ in ["list", "array"]:
+        if message_type.__name__ in {"list", "array"}:
             SequencePin(_field_type)
         else:
             MessagePin(message_type)

--- a/pyflow/packages/RCDT/Core/pin_loader.py
+++ b/pyflow/packages/RCDT/Core/pin_loader.py
@@ -11,26 +11,52 @@ from PyFlow.Core.Common import PinOptions
 
 @dataclass
 class PinData:
+    """Data class to hold information about a pin in PyFlow.
+
+    Attributes:
+        register_name (str): The name used to register the pin.
+        data_type (type): The type of data the pin will handle.
+        color (tuple): The color associated with the pin.
+    """
+
     register_name: str = None
     data_type: type = None
     color: tuple = None
 
 
 class MessagePin:
+    """Class to hold unique message types for PyFlow pins."""
+
     unique_types: set[type] = set()
 
     def __init__(self, message_type: type):
+        """Initialize a MessagePin with a specific message type."""
         MessagePin.unique_types.add(message_type)
 
 
 class SequencePin:
+    """Class to hold unique sequence types for PyFlow pins."""
+
     unique_types: set[str] = set()
 
     def __init__(self, sequence_type: type):
+        """Initialize a SequencePin with a specific sequence type.
+
+        Args:
+            sequence_type (type): The type of the sequence, typically a list or array.
+        """
         SequencePin.unique_types.add(sequence_type)
 
 
 def get_pyflow_pins_from_ros_services(services: set[type]) -> dict:
+    """Create PyFlow pins from ROS service types.
+
+    Args:
+        services (set[type]): A set of ROS service types.
+
+    Returns:
+        dict: A dictionary mapping pin names to PyFlow pin classes.
+    """
     get_types_from_services(services)
     message_types = MessagePin.unique_types
     sequence_types = SequencePin.unique_types
@@ -46,6 +72,13 @@ def get_pyflow_pins_from_ros_services(services: set[type]) -> dict:
 def create_pyflow_pins_from_message_types(
     message_types: set[type], colors: list[tuple], pyflow_pins: dict
 ) -> None:
+    """Create PyFlow pins from message types.
+
+    Args:
+        message_types (set[type]): A set of unique message types.
+        colors (list[tuple]): A list of colors to assign to the pins.
+        pyflow_pins (dict): A dictionary to store the created PyFlow pins.
+    """
     for message_type in message_types:
         pin_data = PinData()
         name = message_type.__name__
@@ -59,6 +92,13 @@ def create_pyflow_pins_from_message_types(
 def create_pyflow_pins_from_sequence_types(
     sequence_types: set[str], colors: list[tuple], pyflow_pins: dict
 ) -> None:
+    """Create PyFlow pins from sequence types.
+
+    Args:
+        sequence_types (set[str]): A set of unique sequence types.
+        colors (list[tuple]): A list of colors to assign to the pins.
+        pyflow_pins (dict): A dictionary to store the created PyFlow pins.
+    """
     for sequence_type in sequence_types:
         pin_data = PinData()
         pin_data.register_name = sequence_type
@@ -68,6 +108,14 @@ def create_pyflow_pins_from_sequence_types(
 
 
 def get_distinct_colors(n_colors: int) -> list[tuple[float, float, float, float]]:
+    """Get a list of distinct RGBA colors.
+
+    Args:
+        n_colors (int): The number of distinct colors to generate.
+
+    Returns:
+        list[tuple[float, float, float, float]]: A list of RGBA colors, each represented as a tuple.
+    """
     rgb_colors = distinctipy.get_colors(n_colors)
     rgba_colors = []
     for rgb_color in rgb_colors:
@@ -80,6 +128,11 @@ def get_distinct_colors(n_colors: int) -> list[tuple[float, float, float, float]
 
 
 def get_types_from_services(service_types: set[type]) -> None:
+    """Extract message types from ROS service types.
+
+    Args:
+        service_types (set[type]): A set of ROS service types.
+    """
     for service_type in service_types:
         service_parts = ["Request", "Response"]
         for service_part in service_parts:
@@ -88,6 +141,11 @@ def get_types_from_services(service_types: set[type]) -> None:
 
 
 def get_types_from_message(message: type) -> None:
+    """Extract message and sequence types from a ROS message.
+
+    Args:
+        message (type): A ROS message type.
+    """
     exclude = ["bool", "str", "int", "float"]
     fields_and_field_types: dict[str, str] = message.get_fields_and_field_types()
     for field, _field_type in fields_and_field_types.items():
@@ -101,22 +159,74 @@ def get_types_from_message(message: type) -> None:
 
 
 def create_pin_from_pin_data(pin_data: PinData) -> type:
+    """Create a PyFlow pin class from PinData.
+
+    Args:
+        pin_data (PinData): The data containing information about the pin.
+
+    Returns:
+        type: A new class that inherits from `PinBase`, representing the PyFlow pin.
+    """
+
     def init(
         self: PinBase, name: str, parent: type, direction: enumerate, **kwargs: any
     ) -> None:
+        """Initialize the PyFlow pin with the given name, parent, and direction.
+
+        Args:
+            self (PinBase): The instance of the pin being initialized.
+            name (str): The name of the pin.
+            parent (type): The parent node type of the pin.
+            direction (enumerate): The direction of the pin (input or output).
+            **kwargs: Additional keyword arguments for initialization.
+        """
         super(type(self), self).__init__(name, parent, direction, **kwargs)
         self.disableOptions(PinOptions.Storable)
 
     def supported_data_types(pin_data: PinData, *_args: any) -> tuple:
+        """Return the supported data types for the pin.
+
+        Args:
+            pin_data (PinData): The data containing information about the pin.
+            *_args (any): Additional arguments (not used).
+
+        Returns:
+            tuple: A tuple containing the register name of the pin.
+        """
         return (pin_data.register_name,)
 
     def pin_data_type_hint(pin_data: PinData) -> tuple:
+        """Return the data type hint for the pin.
+
+        Args:
+            pin_data (PinData): The data containing information about the pin.
+
+        Returns:
+            tuple: A tuple containing the register name and data type of the pin.
+        """
         return pin_data.register_name, pin_data.data_type()
 
     def color(pin_data: PinData, *_args: any) -> tuple:
+        """Return the color associated with the pin.
+
+        Args:
+            pin_data (PinData): The data containing information about the pin.
+            *_args (any): Additional arguments (not used).
+
+        Returns:
+            tuple: A tuple representing the RGBA color of the pin.
+        """
         return pin_data.color
 
     def internal_data_structure(pin_data: PinData) -> type:
+        """Return the internal data structure type for the pin.
+
+        Args:
+            pin_data (PinData): The data containing information about the pin.
+
+        Returns:
+            type: The data type of the pin.
+        """
         return pin_data.data_type
 
     return type(

--- a/pyflow/packages/RCDT/Factories/PinInputWidgetFactory.py
+++ b/pyflow/packages/RCDT/Factories/PinInputWidgetFactory.py
@@ -9,4 +9,11 @@ from PyFlow.UI.Widgets.InputWidgets import DEFAULT_WIDGET_VARIANT
 def getInputWidget(
     dataType, dataSetter, defaultValue, widgetVariant=DEFAULT_WIDGET_VARIANT, **kwds
 ):
+    """Get the input widget for a given data type.
+    Args:
+        dataType: The type of the data.
+        dataSetter: The setter function for the data.
+        defaultValue: The default value for the input widget.
+        widgetVariant: The variant of the widget (default is DEFAULT_WIDGET_VARIANT).
+        **kwds: Additional keyword arguments."""
     pass

--- a/pyflow/packages/RCDT/Factories/UINodeFactory.py
+++ b/pyflow/packages/RCDT/Factories/UINodeFactory.py
@@ -7,4 +7,10 @@ from PyFlow.UI.Canvas.UINodeBase import UINodeBase
 
 
 def createUINode(raw_instance):
+    """Create a UI node from a raw instance.
+    Args:
+        raw_instance: The raw instance of the node to be converted into a UI node.
+    Returns:
+        UINodeBase: An instance of UINodeBase that represents the UI node.
+    """
     return UINodeBase(raw_instance)

--- a/pyflow/packages/RCDT/Factories/UIPinFactory.py
+++ b/pyflow/packages/RCDT/Factories/UIPinFactory.py
@@ -7,4 +7,11 @@ from PyFlow.UI.Canvas.UIPinBase import UIPinBase
 
 
 def createUIPin(owningNode, raw_instance):
+    """Create a UI pin from a raw instance.
+    Args:
+        owningNode: The node that owns this pin.
+        raw_instance: The raw instance of the pin to be converted into a UI pin.
+    Returns:
+        UIPinBase: An instance of UIPinBase that represents the UI pin.
+    """
     return UIPinBase(owningNode, raw_instance)

--- a/pyflow/packages/RCDT/change_camera.py
+++ b/pyflow/packages/RCDT/change_camera.py
@@ -13,7 +13,20 @@ from RCDT.Core.core import PyflowExecutor
 
 
 class ChangeCamera(PyflowExecutor):
+    """Node to change the camera position in the RCDT system.
+
+    Attributes:
+        name (str): The name of the node.
+        input_pin (PinBase): Input pin for the camera position.
+        exec_out (PinBase): Output pin to signal execution completion.
+    """
+
     def __init__(self, name: str):
+        """Initialize the ChangeCamera node with the given name.
+
+        Args:
+            name (str): The name of the node.
+        """
         super().__init__(name)
         self.createInputPin("In", "ExecPin", callback=self.execute)
         self.input_pin: PinBase = self.createInputPin("position", "StringPin")
@@ -24,6 +37,7 @@ class ChangeCamera(PyflowExecutor):
         self.command = command_str.split(" ")
 
     def execute(self, *_args: any, **_kwargs: any) -> None:
+        """Execute the command to change the camera position based on the input pin data."""
         reload(camera_positions)
         position = self.input_pin.getData()
         pose = camera_positions.POSITIONS.get(position)
@@ -42,4 +56,5 @@ class ChangeCamera(PyflowExecutor):
 
     @staticmethod
     def category() -> str:
+        """Return the category of the node."""
         return "Camera"

--- a/pyflow/packages/RCDT/change_camera.py
+++ b/pyflow/packages/RCDT/change_camera.py
@@ -48,7 +48,7 @@ class ChangeCamera(PyflowExecutor):
         msg = f"pose: {{position: {{x: {pose.position.x}, y: {pose.position.y}, z: {pose.position.z}}} orientation: {{x: {pose.orientation.x}, y: {pose.orientation.y}, z: {pose.orientation.z}, w: {pose.orientation.w}}}}}"
         result = subprocess.run(self.command + [msg], check=False, capture_output=True)
         error = result.stderr.decode()
-        if error == "":
+        if not error:
             self.logger.info("Changed camera position successfully.")
             self.exec_out.call()
         else:

--- a/pyflow/packages/RCDT/custom.py
+++ b/pyflow/packages/RCDT/custom.py
@@ -36,7 +36,11 @@ class AnyPinCustom(AnyPin):
         super().__init__(name, owning_node, direction)
 
     def serialize(self) -> dict:
-        """Disable storable before serialization."""
+        """Disable storable before serialization.
+
+        Returns:
+            dict: The serialized data of the pin.
+        """
         self.disableOptions(PinOptions.Storable)
         return super().serialize()
 

--- a/pyflow/packages/RCDT/custom.py
+++ b/pyflow/packages/RCDT/custom.py
@@ -12,9 +12,27 @@ from RCDT.Core.core import PyflowExecutor
 
 
 class AnyPinCustom(AnyPin):
+    """Custom AnyPin implementation for logging any data type.
+
+    This pin can be used to log any data type without restrictions.
+    It inherits from AnyPin and overrides the serialization and disconnection behavior.
+
+    Attributes:
+        name (str): The name of the pin.
+        owning_node (NodeBase): The node that owns this pin.
+        direction (PinDirection): The direction of the pin (input/output).
+    """
+
     def __init__(
         self, name: str, owning_node: NodeBase, direction: PinDirection, **_kwargs: any
     ):
+        """Initialize the AnyPinCustom with the given name, owning node, and direction.
+
+        Args:
+            name (str): The name of the pin.
+            owning_node (NodeBase): The node that owns this pin.
+            direction (PinDirection): The direction of the pin (input/output).
+        """
         super().__init__(name, owning_node, direction)
 
     def serialize(self) -> dict:
@@ -28,11 +46,33 @@ class AnyPinCustom(AnyPin):
 
     @staticmethod
     def internalDataStructure() -> type:  # noqa: N802
+        """Return the internal data structure for this pin type.
+
+        Returns:
+            type: An empty type representing the internal data structure.
+        """
         return type("AnyPinCustom", (type,), {})
 
 
 class LogAnything(PyflowExecutor):
+    """Node to log any data type in the RCDT system.
+
+    This node can log any data type passed to it through the input pin.
+    It inherits from PyflowExecutor and uses a custom AnyPin for input.
+
+    Attributes:
+        name (str): The name of the node.
+        input_pin (PinBase): Input pin for any data type.
+        exec_out (PinBase): Output pin to signal execution completion.
+        logger (Logger): Logger instance for logging messages.
+    """
+
     def __init__(self, name: str):
+        """Initialize the LogAnything node with the given name.
+
+        Args:
+            name (str): The name of the node.
+        """
         super().__init__(name)
         self.createInputPin("In", "ExecPin", callback=self.execute)
         self.exec_out: PinBase = self.createOutputPin("Out", "ExecPin")
@@ -40,10 +80,15 @@ class LogAnything(PyflowExecutor):
         self.logger = getLogger("LogAnything")
 
     def execute(self, *_args: any, **_kwargs: any) -> None:
+        """Execute the logging of data from the input pin.
+
+        This method retrieves the data from the input pin and logs it.
+        """
         data = self.input_pin.getData()
         self.logger.info(data)
         self.exec_out.call()
 
     @staticmethod
     def category() -> str:
+        """Return the category of the node."""
         return "Custom"

--- a/pyflow/packages/RCDT/messages.py
+++ b/pyflow/packages/RCDT/messages.py
@@ -9,6 +9,11 @@ messages: set[type] = set()
 
 
 def add(message: type) -> None:
+    """Add a message type to the set of messages.
+
+    Args:
+        message (type): The message type to add.
+    """
     messages.add(message)
 
 

--- a/pyflow/packages/RCDT/sequence_executor.py
+++ b/pyflow/packages/RCDT/sequence_executor.py
@@ -20,7 +20,18 @@ SERVICE_RESPONSE_TIMEOUT = 20
 
 
 class SequenceExecutor(PyflowNonBlockingExecutor):
+    """Executor for executing sequences of actions in ROS 2.
+
+    This executor listens for a sequence of actions defined in the input pin and executes them in order.
+    It uses an action client to communicate with the action server and handles feedback and results.
+    """
+
     def __init__(self, name: str):
+        """Initialize the SequenceExecutor with the given name.
+
+        Args:
+            name (str): The name of the executor.
+        """
         super().__init__(name)
         self.server_name = "/action_executor"
 
@@ -33,6 +44,7 @@ class SequenceExecutor(PyflowNonBlockingExecutor):
         )
 
     def execute(self, *_args: any, **_kwargs: any) -> None:
+        """Execute the sequence defined in the input pin."""
         goal = Sequence.Goal()
         goal.sequence = self.input_pin.getData()
 
@@ -63,6 +75,14 @@ class SequenceExecutor(PyflowNonBlockingExecutor):
             logger.error(result.message)
 
     def future_done(self, future: Future) -> bool:
+        """Wait for the future to complete or timeout.
+
+        Args:
+            future (Future): The future to wait for.
+
+        Returns:
+            bool: True if the future completed successfully, False if it timed out.
+        """
         self.last_response = time.time()
         while not future.done():
             if time.time() - self.last_response > SERVICE_RESPONSE_TIMEOUT:
@@ -72,6 +92,11 @@ class SequenceExecutor(PyflowNonBlockingExecutor):
         return True
 
     def feedback_callback(self, feedback_msg: Sequence.Impl.FeedbackMessage) -> None:
+        """Callback for feedback messages from the action server.
+
+        Args:
+            feedback_msg (Sequence.Impl.FeedbackMessage): The feedback message received from the action server.
+        """
         feedback = feedback_msg.feedback
         if feedback.success:
             logger.info(feedback.message)
@@ -81,4 +106,9 @@ class SequenceExecutor(PyflowNonBlockingExecutor):
 
     @staticmethod
     def category() -> str:
+        """Get the category of the executor.
+
+        Returns:
+            str: The category of the executor.
+        """
         return "Custom"

--- a/pyflow/packages/RCDT/services.py
+++ b/pyflow/packages/RCDT/services.py
@@ -30,7 +30,7 @@ def add(
 
 # fmt: off
 group = "Detection"
-add("GetMaskProperties","/get_mask_properties", srv.GetMaskProperties, group)
+add("GetMaskProperties", "/get_mask_properties", srv.GetMaskProperties, group)
 add("GetRGBDFromTopic", "/get_rgbd_from_topic", srv.GetRGBDFromTopic, group)
 add("PoseFromPixel", "/pose_from_pixel", srv.PoseFromPixel, group)
 add("PublishImage", "/publish_image", srv.PublishImage, group)
@@ -38,7 +38,7 @@ add("PublishMasks", "/publish_masks", srv.PublishMasks, group)
 add("SegmentImage", "/segment_image", srv.SegmentImage, group)
 add("SelectImageFromList", "/select_image_from_list", srv.SelectImageFromList, group)
 add("SelectPickLocation", "/select_pick_location", srv.SelectPickLocation, group)
-add("SelectPlaceLocation","/select_place_location",srv.SelectPlaceLocation, group)
+add("SelectPlaceLocation", "/select_place_location", srv.SelectPlaceLocation, group)
 
 group = "Utilities"
 add("ExpressPoseInOtherFrame", "/express_pose_in_other_frame", srv.ExpressPoseInOtherFrame, group)

--- a/pyflow/packages/RCDT/services.py
+++ b/pyflow/packages/RCDT/services.py
@@ -14,6 +14,14 @@ service_definitions: list[ServiceDefinition] = []
 def add(
     pyflow_name: str, service_name: str, service_type: type, pyflow_group: str = None
 ) -> None:
+    """Add a service definition to the list of service definitions.
+
+    Args:
+        pyflow_name (str): The name of the service in PyFlow.
+        service_name (str): The name of the service as it will be used in ROS.
+        service_type (type): The type of the service.
+        pyflow_group (str, optional): The group to which the service belongs in PyFlow.
+    """
     unique_service_types.add(service_type)
     service_definitions.append(
         ServiceDefinition(service_name, service_type, pyflow_name, pyflow_group)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,11 @@
 split-on-trailing-comma = false
 
 [tool.ruff.lint]
-select = ["I", "F", "E", "W", "B", "N", "A", "C4", "PL", "Q000", "SIM", "ANN", "ARG", "ERA"]
-ignore = ["E501", "ANN204"]
+select = ["I", "F", "E", "W", "B", "N", "A", "C4", "PL", "Q000", "SIM", "ANN", "ARG", "ERA", "D"]
+ignore = ["E501", "ANN204","D100", "D104"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.pytest.ini_options]
 timeout = 90

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ split-on-trailing-comma = false
 
 [tool.ruff.lint]
 select = ["I", "F", "E", "W", "B", "N", "A", "C4", "PL", "Q000", "SIM", "ANN", "ARG", "ERA", "D", "DOC"]
-ignore = ["E501", "ANN204","D100", "D104", "PLR0917","PLR0914"]
+ignore = ["E501", "ANN204", "ANN401", "D100", "D104", "PLR0917","PLR0914"]
 preview = true
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+[tool.ruff]
+exclude = ["ros2_ws/src/rcdt_detection/**"]
+
 [tool.ruff.lint.isort]
 split-on-trailing-comma = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,15 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-[tool.ruff]
-exclude = ["ros2_ws/src/rcdt_detection/**"]
-
 [tool.ruff.lint.isort]
 split-on-trailing-comma = false
 
 [tool.ruff.lint]
-select = ["I", "F", "E", "W", "B", "N", "A", "C4", "PL", "Q000", "SIM", "ANN", "ARG", "ERA", "D"]
+select = ["I", "F", "E", "W", "B", "N", "A", "C4", "PL", "Q000", "SIM", "ANN", "ARG", "ERA", "D", "DOC"]
 ignore = ["E501", "ANN204","D100", "D104"]
+preview = true
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,4 @@ convention = "google"
 
 [tool.pytest.ini_options]
 timeout = 90
+norecursedirs = ["install", "build", "log"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ split-on-trailing-comma = false
 
 [tool.ruff.lint]
 select = ["I", "F", "E", "W", "B", "N", "A", "C4", "PL", "Q000", "SIM", "ANN", "ARG", "ERA", "D", "DOC"]
-ignore = ["E501", "ANN204","D100", "D104"]
+ignore = ["E501", "ANN204","D100", "D104", "PLR0917","PLR0914"]
 preview = true
 
 [tool.ruff.lint.pydocstyle]

--- a/ros2_ws/src/rcdt_actions/rcdt_actions/definitions/definitions.py
+++ b/ros2_ws/src/rcdt_actions/rcdt_actions/definitions/definitions.py
@@ -13,19 +13,52 @@ TIME_OUT = 3
 
 
 def info(node: Node, message: str) -> None:
+    """Log an info message using the provided node's logger.
+
+    Args:
+        node (Node): The ROS 2 node to use for logging.
+        message (str): The message to log.
+
+    """
     node.get_logger().info(message)
 
 
 def warn(node: Node, message: str) -> None:
+    """Warn about a message using the provided node's logger.
+
+    Args:
+        node (Node): The ROS 2 node to use for logging.
+        message (str): The message to log.
+
+    """
     node.get_logger().warn(message)
 
 
 def error(node: Node, message: str) -> None:
+    """Log an error message using the provided node's logger.
+
+    Args:
+        node (Node): The ROS 2 node to use for logging.
+        message (str): The message to log.
+
+    """
     node.get_logger().error(message)
 
 
 @dataclass
 class Action:
+    """Class representing an action to be executed in a sequence.
+
+    Attributes:
+        service_name (str): The name of the service to call.
+        service_type (object): The type of the service to call.
+        args (dict | None): A dictionary of arguments to pass to the service.
+        links (dict | None): A dictionary of links where keys are output arguments and values are input arguments.
+        node (Node | None): The ROS 2 node associated with the action.
+        client (Client | None): The ROS 2 client for the service.
+
+    """
+
     service_name: str
     service_type: object
     args: dict | None = None
@@ -34,14 +67,41 @@ class Action:
     client: Client | None = None
 
     def set_args(self, args: dict) -> "Action":
+        """Set the arguments for the action.
+
+        Args:
+            args (dict): A dictionary of arguments to set for the action.
+
+        Returns:
+            Action: The current instance of the Action class with updated arguments.
+
+        """
         self.args = args
         return self
 
     def set_links(self, links: dict) -> "Action":
+        """Set the links for the action.
+
+        Args:
+            links (dict): A dictionary of links where keys are output arguments and values are input arguments.
+
+        Returns:
+            Action: The current instance of the Action class with updated links.
+
+        """
         self.links = links
         return self
 
     def fill_from_arguments(self, request: object) -> bool:
+        """Fill the request object with arguments from the action.
+
+        Args:
+            request (object): The request object to fill with arguments.
+
+        Returns:
+            bool: True if the request was filled successfully, False otherwise.
+
+        """
         if self.args is None:
             return True
         for key, value in self.args.items():
@@ -56,6 +116,16 @@ class Action:
         return True
 
     def fill_from_last_result(self, request: object, last_result: object) -> bool:
+        """Fill the request object with values from the last result based on links.
+
+        Args:
+            request (object): The request object to fill with values from the last result.
+            last_result (object): The last result object containing values to fill into the request.
+
+        Returns:
+            bool: True if the request was filled successfully, False otherwise.
+
+        """
         if self.links is None:
             return True
         for arg_out, arg_in in self.links.items():
@@ -75,6 +145,15 @@ class Action:
             return True
 
     def call(self, last_result: object) -> tuple[bool, object]:
+        """Call the service associated with the action.
+
+        Args:
+            last_result (object): The last result object to use for filling the request.
+
+        Returns:
+            tuple[bool, object]: A tuple containing a boolean indicating success and the response object.
+
+        """
         if self.client is None:
             self.client = self.node.create_client(self.service_type, self.service_name)
 
@@ -94,6 +173,19 @@ class Action:
 
 @dataclass
 class Sequence:
+    """Class representing a sequence of actions to be executed.
+
+    Attributes:
+        name (str): The name of the sequence.
+        actions (list[Action]): A list of actions to be executed in the sequence.
+        node (Node | None): The ROS 2 node associated with the sequence.
+        goal_handle (ServerGoalHandle | None): The goal handle for the action server.
+        last_result (object): The last result from the executed action.
+        success (bool): Indicates whether the sequence was executed successfully.
+        index (int): The current index of the action being executed in the sequence.
+
+    """
+
     name: str
     actions: list[Action]
     node: Node | None = None
@@ -103,19 +195,34 @@ class Sequence:
     index = 0
 
     def reset(self) -> None:
+        """Reset the sequence to its initial state."""
         self.success = True
         self.index = 0
 
     def is_finished(self) -> bool:
+        """Check if the sequence has finished executing.
+
+        Returns:
+            bool: True if the sequence is finished, False otherwise.
+
+        """
         return not self.success or self.index >= len(self.actions)
 
     def current_action(self) -> Action:
+        """Get the current action being executed in the sequence.
+
+        Returns:
+            Action: The current action object.
+
+        """
         return self.actions[self.index]
 
     def log_start(self) -> None:
+        """Log the start of the sequence execution."""
         info(self.node, f"Starting execution of sequence '{self.name}'.")
 
     def log_progress(self) -> None:
+        """Log the progress of the sequence execution.Publishes feedback to the goal handle if available. If the sequence is successful, logs a success message; otherwise, logs a failure message."""
         feedback = SequenceMsg.Feedback()
         feedback.success = self.success
         if self.success:
@@ -128,17 +235,25 @@ class Sequence:
         self.goal_handle.publish_feedback(feedback)
 
     def log_result(self) -> None:
+        """Log the result of the sequence execution. If the sequence was successful, logs a success message; otherwise, logs a failure message."""
         if self.success:
             info(self.node, f"Sequency '{self.name}' was executed successfully.")
         else:
             error(self.node, f"Failed to execute sequence '{self.name}'.")
 
     def call(self) -> None:
+        """Call the current action in the sequence. Sets the node for the action and calls the action's `call` method. Updates the `success` and `last_result` attributes based on the action's result."""
         action = self.actions[self.index]
         action.node = self.node
         self.success, self.last_result = action.call(self.last_result)
 
     def execute(self) -> bool:
+        """Execute the sequence of actions. Resets the sequence, logs the start, and iterates through the actions until finished. Logs the progress after each action call and logs the final result.
+
+        Returns:
+            bool: True if the sequence was executed successfully, False otherwise.
+
+        """
         self.reset()
         self.log_start()
         while not self.is_finished():

--- a/ros2_ws/src/rcdt_actions/rcdt_actions/detection/detection.py
+++ b/ros2_ws/src/rcdt_actions/rcdt_actions/detection/detection.py
@@ -8,8 +8,20 @@ from rcdt_actions.definitions import Action
 
 
 def get_rgbd_from_topic() -> Action:
+    """Create an action to get RGBD data from a topic.
+
+    Returns:
+        Action: An action that can be used to get RGBD data from a topic.
+
+    """
     return Action("/get_rgbd_from_topic", GetRGBDFromTopic)
 
 
 def segment_image() -> Action:
+    """Create an action to segment an image.
+
+    Returns:
+        Action: An action that can be used to segment an image.
+
+    """
     return Action("/segment_image", SegmentImage)

--- a/ros2_ws/src/rcdt_actions/rcdt_actions/gripper/gripper.py
+++ b/ros2_ws/src/rcdt_actions/rcdt_actions/gripper/gripper.py
@@ -8,8 +8,20 @@ from rcdt_actions.definitions import Action
 
 
 def open_gripper() -> Action:
+    """Create an action to open the gripper.
+
+    Returns:
+        Action: An action that can be used to open the gripper.
+
+    """
     return Action("/open_gripper", Trigger)
 
 
 def close_gripper() -> Action:
+    """Create an action to close the gripper.
+
+    Returns:
+        Action: An action that can be used to close the gripper.
+
+    """
     return Action("/close_gripper", Trigger)

--- a/ros2_ws/src/rcdt_actions/rcdt_actions/moveit/moveit.py
+++ b/ros2_ws/src/rcdt_actions/rcdt_actions/moveit/moveit.py
@@ -10,12 +10,30 @@ ns = "/moveit_manager"
 
 
 def tranform_goal_pose() -> Action:
+    """Create an action to transform a goal pose.
+
+    Returns:
+        Action: An action that can be used to transform a goal pose.
+
+    """
     return Action(f"{ns}/transform_goal_pose", TransformGoalPose)
 
 
 def move_to_configuration() -> Action:
+    """Create an action to move to a configuration.
+
+    Returns:
+        Action: An action that can be used to move to a configuration.
+
+    """
     return Action(f"{ns}/move_to_configuration", MoveToConfiguration)
 
 
 def move_hand_to_pose() -> Action:
+    """Create an action to move the hand to a pose.
+
+    Returns:
+        Action: An action that can be used to move the hand to a pose.
+
+    """
     return Action(f"{ns}/move_hand_to_pose", MoveHandToPose)

--- a/ros2_ws/src/rcdt_actions/src_py/action_executor.py
+++ b/ros2_ws/src/rcdt_actions/src_py/action_executor.py
@@ -18,7 +18,10 @@ from rclpy.node import Node
 
 
 class ActionExecutor(Node):
+    """ActionExecutor node to handle action requests for sequences."""
+
     def __init__(self) -> bool:
+        """Initialize the ActionExecutor node."""
         super().__init__("action_executor")
 
         self.action_server = ActionServer(
@@ -30,6 +33,17 @@ class ActionExecutor(Node):
         )
 
     def callback(self, goal_handle: ServerGoalHandle) -> Sequence.Result:
+        """Callback for the action server.
+
+        This method is called when a goal is received by the action server.
+        It checks if the requested sequence exists, executes it, and returns the result.
+
+        Args:
+            goal_handle (ServerGoalHandle): The handle for the goal.
+
+        Returns:
+            Sequence.Result: The result of the sequence execution.
+        """
         reload(actions)
 
         goal: Sequence.Goal = goal_handle.request
@@ -59,6 +73,7 @@ class ActionExecutor(Node):
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the ROS 2 node and start the action executor."""
     rclpy.init(args=args)
     executor = MultiThreadedExecutor()
     node = ActionExecutor()

--- a/ros2_ws/src/rcdt_detection/launch/detection_services.launch.py
+++ b/ros2_ws/src/rcdt_detection/launch/detection_services.launch.py
@@ -12,6 +12,11 @@ from rcdt_utilities.launch_utils import get_lib_path
 
 
 def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for the RCDT detection services.
+
+    Returns:
+        LaunchDescription: The launch description for the RCDT detection services.
+    """
     nodes = []
     executables_directory = get_lib_path("rcdt_detection")
     executables = glob(executables_directory + "/*.py")

--- a/ros2_ws/src/rcdt_detection/launch/realsense.launch.py
+++ b/ros2_ws/src/rcdt_detection/launch/realsense.launch.py
@@ -12,6 +12,14 @@ use_sim_arg = LaunchArgument("simulation", True, [True, False])
 
 
 def launch_setup(context: LaunchContext) -> list:
+    """Setup the launch description for the realsense camera.
+
+    Args:
+        context (LaunchContext): The launch context.
+
+    Returns:
+        list: A list of actions to be executed.
+    """
     use_sim = use_sim_arg.value(context)
 
     if use_sim:
@@ -45,6 +53,11 @@ def launch_setup(context: LaunchContext) -> list:
 
 
 def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for the realsense camera.
+
+    Returns:
+        LaunchDescription: The launch description for the realsense camera.
+    """
     return LaunchDescription(
         [
             use_sim_arg.declaration,

--- a/ros2_ws/src/rcdt_detection/rcdt_detection/image_manipulation.py
+++ b/ros2_ws/src/rcdt_detection/rcdt_detection/image_manipulation.py
@@ -12,7 +12,15 @@ from sensor_msgs.msg import Image
 
 
 def slice_image_to_stride(image: ndarray, stride: int = 32) -> ndarray:
-    """Slice image to confirm to a given stride length"""
+    """Slice image to confirm to a given stride length.
+
+    Args:
+        image (ndarray): The input image to be sliced.
+        stride (int): The stride length to which the image dimensions should conform.
+
+    Returns:
+        ndarray: The sliced image with dimensions that are multiples of the stride.
+    """
     rows = image.shape[0]
     cols = image.shape[1]
     row_dist = rows % stride
@@ -26,14 +34,30 @@ def slice_image_to_stride(image: ndarray, stride: int = 32) -> ndarray:
 def ros_image_to_cv2_image_sliced(
     image_message: Image, desired_encoding: str = "passthrough", stride: int = 32
 ) -> ndarray:
-    """Slice an image so that its dimensions are a multiple of stride"""
+    """Slice an image so that its dimensions are a multiple of stride.
+
+    Args:
+        image_message (Image): The ROS Image message to be converted.
+        desired_encoding (str): The desired encoding for the image.
+        stride (int): The stride length to which the image dimensions should conform.
+
+    Returns:
+        ndarray: The sliced image with dimensions that are multiples of the stride.
+    """
     return slice_image_to_stride(
         cv_utils.ros_image_to_cv2_image(image_message, desired_encoding), stride
     )
 
 
 def segmentation_mask_to_binary_mask(mask: torch.Tensor) -> ndarray:
-    """Convert given mask to np.ndarray with range [0, 255], dtype=uint8, and dimensions [height, width, channels]."""
+    """Convert given mask to np.ndarray with range [0, 255], dtype=uint8, and dimensions [height, width, channels].
+
+    Args:
+        mask (torch.Tensor): The input mask tensor, typically with shape [1, channels, height, width].
+
+    Returns:
+        ndarray: The binary mask as a numpy array with shape [height, width, channels] and values in the range [0, 255].
+    """
     binary_mask = mask.data.cpu().numpy().astype(uint8)
     binary_mask = binary_mask * 255
     binary_mask = binary_mask.transpose(1, 2, 0)
@@ -41,10 +65,24 @@ def segmentation_mask_to_binary_mask(mask: torch.Tensor) -> ndarray:
 
 
 def single_to_three_channel(image: ndarray) -> ndarray:
-    """Convert given single-channel image to three-channel image."""
+    """Convert given single-channel image to three-channel image.
+
+    Args:
+        image (ndarray): The input single-channel image.
+
+    Returns:
+        ndarray: The converted three-channel image.
+    """
     return cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
 
 
 def three_to_single_channel(image: ndarray) -> ndarray:
-    """Convert given three-channel image to single-channel image."""
+    """Convert given three-channel image to single-channel image.
+
+    Args:
+        image (ndarray): The input three-channel image.
+
+    Returns:
+        ndarray: The converted single-channel image.
+    """
     return cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)

--- a/ros2_ws/src/rcdt_detection/rcdt_detection/image_manipulation.py
+++ b/ros2_ws/src/rcdt_detection/rcdt_detection/image_manipulation.py
@@ -59,7 +59,7 @@ def segmentation_mask_to_binary_mask(mask: torch.Tensor) -> ndarray:
         ndarray: The binary mask as a numpy array with shape [height, width, channels] and values in the range [0, 255].
     """
     binary_mask = mask.data.cpu().numpy().astype(uint8)
-    binary_mask = binary_mask * 255
+    binary_mask *= 255
     binary_mask = binary_mask.transpose(1, 2, 0)
     return binary_mask
 

--- a/ros2_ws/src/rcdt_detection/rcdt_detection/mask_properties.py
+++ b/ros2_ws/src/rcdt_detection/rcdt_detection/mask_properties.py
@@ -27,26 +27,65 @@ logger = logging.get_logger(__name__)
 
 @dataclass
 class ImageUtils:
+    """Utility class for depth image manipulation.
+
+    This class provides methods to work with depth images, including checking point clearance,
+    calculating average depth, and checking if points are inside the image dimensions.
+
+    Attributes:
+        image (np.ndarray): The depth image in millimeters, where each pixel value represents the depth in millimeters.
+    """
+
     image: np.ndarray
 
     def average_depth(self, points: Point2DList) -> float:
-        """Return the average depth value."""
+        """Return the average depth value.
+
+        Args:
+            points (Point2DList): A list of 2D points for which the average depth is calculated.
+
+        Returns:
+            float: The average depth value in meters.
+        """
         return np.mean([self.depth_value(point) for point in points.points])
 
     def is_point_inside(self, point: Point2D) -> bool:
-        """Return if this point falls inside given image dimensions."""
+        """Return if this point falls inside given image dimensions.
+
+        Args:
+            point (Point2D): The 2D point to check.
+
+        Returns:
+            bool: True if the point is inside the image dimensions, False otherwise.
+        """
         rows, cols = self.image.shape
         x, y = point.as_tuple
         return 0 <= x < cols and 0 <= y < rows
 
     def is_pointlist_inside(self, points: Point2DList) -> bool:
-        """Test if all points in group fall inside given image."""
+        """Test if all points in group fall inside given image.
+
+        Args:
+            points (Point2DList): A list of 2D points to check.
+
+        Returns:
+            bool: True if all points are inside the image dimensions, False otherwise.
+        """
         return all(self.is_point_inside(point) for point in points.points)
 
     def is_point_clearance(
         self, point: Point2D, object_depth: float, min_depth: float = 0.04
     ) -> bool:
-        """Test if area arround point is deeper than object_depth, and is at least min_depth relative to object_depth."""
+        """Test if area arround point is deeper than object_depth, and is at least min_depth relative to object_depth.
+
+        Args:
+            point (Point2D): The 2D point to check.
+            object_depth (float): The depth of the object in meters.
+            min_depth (float): The minimum depth difference required from the object depth.
+
+        Returns:
+            bool: True if the area around the point is deeper than object_depth and at least min_depth deeper, False otherwise.
+        """
         point_group = point.surrounding_points()
         if not self.is_pointlist_inside(point_group):
             return False
@@ -55,20 +94,53 @@ class ImageUtils:
         return depth_difference > min_depth
 
     def is_points_clearance(self, object_depth: float, points: Point2DList) -> bool:
-        """Test if all corresponding points in depth_image are deeper than object_depth."""
+        """Test if all corresponding points in depth_image are deeper than object_depth.
+
+        Args:
+            object_depth (float): The depth of the object in meters.
+            points (Point2DList): A list of 2D points to check.
+
+        Returns:
+            bool: True if all points are clear, False otherwise.
+        """
         return all(
             self.is_point_clearance(point, object_depth) for point in points.points
         )
 
     def depth_value(self, point: Point2D) -> float:
-        """Return the depth value in meters."""
+        """Return the depth value in meters.
+
+        Args:
+            point (Point2D): The 2D point for which the depth value is retrieved.
+
+        Returns:
+            float: The depth value in meters.
+        """
         return self.image[int(point.y), int(point.x)] / 1000
 
 
 class MaskProperties:
+    """Class to hold properties of a mask and its corresponding depth image.
+
+    This class provides methods to analyze the mask, such as finding contours, bounding boxes,
+    centroids, average hue, average depth, and suitable pickup points.
+
+    Atributes:
+        mask (np.ndarray): The mask image, typically a 3-channel RGB image.
+        depth_image (np.ndarray): The depth image in millimeters, where each pixel value represents the depth in millimeters.
+        intrinsics (rs2.intrinsics): The camera intrinsics for depth image.
+    """
+
     def __init__(
         self, mask: np.ndarray, depth_image: np.ndarray, intrinsics: rs2.intrinsics
     ):
+        """Initialize the MaskProperties with a mask, depth image, and camera intrinsics.
+
+        Args:
+            mask (np.ndarray): The mask image, typically a 3-channel RGB image.
+            depth_image (np.ndarray): The depth image in millimeters, where each pixel value represents the depth in millimeters.
+            intrinsics (rs2.intrinsics): The camera intrinsics for depth image.
+        """
         self.mask = mask
         self.depth_image = depth_image
         self.depth_image_utils = ImageUtils(depth_image)
@@ -77,15 +149,23 @@ class MaskProperties:
 
     @property
     def rows(self) -> int:
+        """Returns the number of rows in the depth image."""
         return self.depth_image.shape[0]
 
     @property
     def cols(self) -> int:
+        """Returns the number of columns in the depth image."""
         return self.depth_image.shape[1]
 
     @property
     def contour(self) -> list[list[np.ndarray]]:
-        """Returns the main contour, so that tiny contours due to noise are eliminated."""
+        """Returns the main contour, so that tiny contours due to noise are eliminated.
+
+        The main contour is the largest contour found in the single-channel mask.
+
+        Returns:
+            list[list[np.ndarray]]: The largest contour found in the single-channel mask.
+        """
         contours, _ = cv2.findContours(
             self.single_channel, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
         )
@@ -94,13 +174,25 @@ class MaskProperties:
 
     @property
     def bounding_box(self) -> BoundingBox:
-        """Returns the bounding box of the main contour."""
+        """Returns the bounding box of the main contour.
+
+        The bounding box is calculated using the minimum area rectangle that can enclose the contour.
+
+        Returns:
+            BoundingBox: The bounding box of the main contour, represented as a BoundingBox object.
+        """
         (x, y), (w, h), angle_deg = cv2.minAreaRect(self.contour)
         return BoundingBox(x, y, w, h, angle_deg)
 
     @property
     def centroid(self) -> Point2D:
-        """Returns the centroid of the mask."""
+        """Returns the centroid of the mask.
+
+        The centroid is calculated using image moments, which provide the center of mass of the mask.
+
+        Returns:
+            Point2D: The centroid of the mask, represented as a Point2D object.
+        """
         moments = cv2.moments(self.single_channel)
         x = float(moments["m10"] / moments["m00"])
         y = float(moments["m01"] / moments["m00"])
@@ -108,7 +200,13 @@ class MaskProperties:
 
     @property
     def avg_hue(self) -> float:
-        """Returns average hue of the mask."""
+        """Returns the average hue of the mask.
+
+        The average hue is calculated by converting the average RGB values of the mask to HSV and extracting the hue component.
+
+        Returns:
+            float: The average hue of the mask in degrees, ranging from 0 to 360.
+        """
         b_mean, g_mean, r_mean = np.nanmean(
             np.where(self.mask == 0.0, np.nan, self.mask), axis=(0, 1)
         )
@@ -117,17 +215,37 @@ class MaskProperties:
 
     @property
     def average_depth(self) -> float:
-        """Returns the average depth value of the mask in meters."""
+        """Returns the average depth value of the mask in meters.
+
+        The average depth is calculated using the mean of the depth values in the depth image, masked by the single-channel mask.
+
+        Returns:
+            float: The average depth value of the mask in meters.
+        """
         average_depth_mm = cv2.mean(self.depth_image, mask=self.single_channel)[0]
         return average_depth_mm / 1000
 
     @property
     def mode_depth(self) -> float:
-        """return the most common (mode) depth value of the mask."""
+        """Returns the mode depth value of the mask.
+
+        The mode depth is calculated by finding the most common depth value in the masked depth image.
+
+        Returns:
+            float: The mode depth value of the mask in millimeters.
+        """
         masked_depth_values = self.depth_image[self.single_channel > 0]
         return np.bincount(masked_depth_values).argmax()
 
     def refined_mask(self) -> Self:
+        """Returns a refined mask based on the mode depth value.
+
+        The refined mask is created by applying a condition that keeps only the pixels within a certain range around the mode depth value.
+        The range is defined as mode_depth ± delta, where delta is set to 30 mm.
+
+        Returns:
+            MaskProperties: A new MaskProperties object with the refined mask, depth image, and intrinsics.
+        """
         delta = 30
         min_depth = self.mode_depth - delta
         max_depth = self.mode_depth + delta
@@ -139,6 +257,16 @@ class MaskProperties:
 
     @property
     def pickup_points(self) -> tuple[Point2DList, Point2DList]:
+        """Returns suitable and non-suitable pickup points based on the bounding box's long sides offset.
+
+        The suitable pickup points are those that have sufficient clearance from the object depth,
+        while the non-suitable points are those that do not meet the clearance criteria.
+
+        Returns:
+            tuple[Point2DList, Point2DList]: A tuple containing two Point2DList objects:
+                - suitable: Points that are clear for pickup.
+                - non_suitable: Points that are not clear for pickup.
+        """
         point_pairs = self.bounding_box.long_sides_offset.point_pairs()
         clearance = np.array(
             [
@@ -154,6 +282,14 @@ class MaskProperties:
 
     @property
     def chosen_pickup_point(self) -> Point2D | None:
+        """Returns a suitable pickup point based on the available points.
+
+        The chosen pickup point is the middle point of the suitable pickup points.
+        If there are no suitable points, it returns None.
+
+        Returns:
+            Point2D | None: The chosen pickup point as a Point2D object, or None if no suitable points are available.
+        """
         suitable, non_suitable = self.pickup_points
 
         if len(suitable.points) == 0:
@@ -162,6 +298,18 @@ class MaskProperties:
 
     @property
     def filter_visualization(self) -> np.ndarray:
+        """Returns a visualization of the mask with the bounding box, long sides offset, and pickup points.
+
+        The visualization includes:
+            - The bounding box corners connected by lines.
+            - The long sides offset represented by magenta lines.
+            - Suitable pickup points marked in red.
+            - Non-suitable pickup points marked in blue.
+        If there are no suitable pickup points, the chosen pickup point is marked in green.
+
+        Returns:
+            np.ndarray: The visualization image with the mask, bounding box, long sides offset, and pickup points.
+        """
         image = self.mask.copy()
 
         for i in range(len(self.bounding_box.corners)):
@@ -202,12 +350,30 @@ class MaskProperties:
         return image
 
     def point_2d_to_3d(self, point: Point2D) -> Point3D:
+        """Convert a 2D point in the mask to a 3D point using the depth image and camera intrinsics.
+
+        Args:
+            point (Point2D): The 2D point to convert.
+
+        Returns:
+            Point3D: The corresponding 3D point in the camera coordinate system.
+        """
         x, y, z = rs2.rs2_deproject_pixel_to_point(
             self.intrinsics, point.as_array, self.depth_image_utils.depth_value(point)
         )
         return Point3D(x, y, z)
 
     def point_2d_to_pose(self, point_2d: Point2D) -> Pose:
+        """Convert a 2D point in the mask to a Pose object.
+
+        The Pose object is created using the 3D point corresponding to the 2D point and the bounding box angle.
+
+        Args:
+            point_2d (Point2D): The 2D point to convert.
+
+        Returns:
+            Pose: The corresponding Pose object, which includes the 3D point and the bounding box angle.
+        """
         point_3d = self.point_2d_to_3d(point_2d)
         # make sure bounding box angle is in the range of 0 to pi radians
         bounding_box_angle = (

--- a/ros2_ws/src/rcdt_detection/rcdt_detection/segmentation.py
+++ b/ros2_ws/src/rcdt_detection/rcdt_detection/segmentation.py
@@ -15,7 +15,14 @@ PATH_SAM2: str = str(Path.home() / "models" / "sam2.1_b.pt")
 
 
 def load_segmentation_model(model: Literal["SAM2", "FastSAM"] = "FastSAM") -> Model:
-    """Load segmentation model from given path."""
+    """Load segmentation model from given path.
+
+    Args:
+        model (Literal["SAM2", "FastSAM"]): The model to load, either "SAM2" or "FastSAM".
+
+    Returns:
+        Model: The loaded segmentation model.
+    """
     match model:
         case "FastSAM":
             return FastSAM(PATH_FASTSAM)
@@ -24,7 +31,15 @@ def load_segmentation_model(model: Literal["SAM2", "FastSAM"] = "FastSAM") -> Mo
 
 
 def segment_image(model: Model, image: np.ndarray) -> Results:
-    """Segment given image using given model."""
+    """Segment given image using given model.
+
+    Args:
+        model (Model): The segmentation model to use.
+        image (np.ndarray): The input image to segment.
+
+    Returns:
+        Results: The segmentation results containing masks and other information.
+    """
     if isinstance(model, FastSAM):
         height, width, _ = image.shape
         return model(image, imgsz=(height, width))[0]

--- a/ros2_ws/src/rcdt_detection/src_py/get_mask_properties.py
+++ b/ros2_ws/src/rcdt_detection/src_py/get_mask_properties.py
@@ -17,11 +17,31 @@ ros_logger = logging.get_logger(__name__)
 
 
 class GetMaskProperties(Node):
+    """Node to get properties of a mask from a depth image and camera info.
+
+    This node provides a service that takes a mask, depth image, and camera info,
+    and returns properties such as contour, bounding box, centroid, and average hue.
+
+    Attributes:
+        node_name (str): The name of the node.
+        service_name (str): The name of the service provided by this node.
+    """
+
     def __init__(self) -> None:
+        """Initialize the GetMaskProperties node."""
         super().__init__("get_mask_properties")
         self.create_service(Srv, "/get_mask_properties", self.callback)
 
     def callback(self, request: Srv.Request, response: Srv.Response) -> Srv.Response:
+        """Callback function to handle the service request.
+
+        Args:
+            request (Srv.Request): The request containing the mask, depth image, and camera info.
+            response (Srv.Response): The response to be filled with mask properties.
+
+        Returns:
+            Srv.Response: The response containing the properties of the mask.
+        """
         mask = ros_image_to_cv2_image(request.mask)
         depth_image = ros_image_to_cv2_image(request.depth_image)
         intrinsics = camera_info_to_intrinsics(request.camera_info)
@@ -43,6 +63,11 @@ class GetMaskProperties(Node):
 
 
 def main(args: str = None) -> None:
+    """Initialize the ROS 2 node and spin it.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     node = GetMaskProperties()
     spin_node(node)

--- a/ros2_ws/src/rcdt_detection/src_py/get_mask_properties.py
+++ b/ros2_ws/src/rcdt_detection/src_py/get_mask_properties.py
@@ -32,7 +32,8 @@ class GetMaskProperties(Node):
         super().__init__("get_mask_properties")
         self.create_service(Srv, "/get_mask_properties", self.callback)
 
-    def callback(self, request: Srv.Request, response: Srv.Response) -> Srv.Response:
+    @staticmethod
+    def callback(request: Srv.Request, response: Srv.Response) -> Srv.Response:
         """Callback function to handle the service request.
 
         Args:

--- a/ros2_ws/src/rcdt_detection/src_py/get_rgbd_from_topic.py
+++ b/ros2_ws/src/rcdt_detection/src_py/get_rgbd_from_topic.py
@@ -40,7 +40,7 @@ class GetRGBDFromTopic(Node):
         Returns:
             Srv.Response: The response containing the RGB image, depth image, and camera info.
         """
-        if request.topic == "":
+        if not request.topic:
             ros_logger.error("No topic was specified. Exit.")
             response.success = False
             return response

--- a/ros2_ws/src/rcdt_detection/src_py/get_rgbd_from_topic.py
+++ b/ros2_ws/src/rcdt_detection/src_py/get_rgbd_from_topic.py
@@ -15,11 +15,31 @@ ros_logger = logging.get_logger(__name__)
 
 
 class GetRGBDFromTopic(Node):
+    """Node to get RGBD data from a specified topic.
+
+    This node provides a service that waits for an RGBD message on a specified topic
+    and returns the RGB image, depth image, and their respective camera info.
+
+    Attributes:
+        node_name (str): The name of the node.
+        service_name (str): The name of the service provided by this node.
+    """
+
     def __init__(self) -> None:
+        """Node to get RGBD data from a specified topic."""
         super().__init__("get_rgbd_from_topic")
         self.create_service(Srv, "/get_rgbd_from_topic", self.callback)
 
     def callback(self, request: Srv.Request, response: Srv.Response) -> Srv.Response:
+        """Callback function to handle the service request.
+
+        Args:
+            request (Srv.Request): The request containing the topic to listen to.
+            response (Srv.Response): The response to be filled with RGBD data.
+
+        Returns:
+            Srv.Response: The response containing the RGB image, depth image, and camera info.
+        """
         if request.topic == "":
             ros_logger.error("No topic was specified. Exit.")
             response.success = False
@@ -39,6 +59,11 @@ class GetRGBDFromTopic(Node):
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the ROS 2 node and spin it.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     node = GetRGBDFromTopic()
     spin_node(node)

--- a/ros2_ws/src/rcdt_detection/src_py/pose_from_pixel.py
+++ b/ros2_ws/src/rcdt_detection/src_py/pose_from_pixel.py
@@ -17,13 +17,31 @@ ros_logger = logging.get_logger(__name__)
 
 
 class PoseFromPixel(Node):
-    """Converts a pixel to the corresponding pose in meters."""
+    """Converts a pixel to the corresponding pose in meters.
+
+    This node provides a service that takes a pixel location and depth image,
+    and returns the 3D pose of that pixel in the camera's coordinate frame.
+
+    Attributes:
+        node_name (str): The name of the node.
+        service_name (str): The name of the service provided by this node.
+    """
 
     def __init__(self) -> None:
+        """Initialize the PoseFromPixel node."""
         super().__init__("pose_from_pixel")
         self.create_service(Srv, "/pose_from_pixel", self.callback)
 
     def callback(self, request: Srv.Request, response: Srv.Response) -> Srv.Response:
+        """Callback function to handle the service request.
+
+        Args:
+            request (Srv.Request): The request containing the pixel location and depth image.
+            response (Srv.Response): The response to be filled with the pose.
+
+        Returns:
+            Srv.Response: The response containing the pose of the pixel in the camera's coordinate frame.
+        """
         cv2_image = ros_image_to_cv2_image(request.depth_image)
         height, width = cv2_image.shape
         intr = calculate_intrinsics(request.camera_info)
@@ -52,6 +70,16 @@ class PoseFromPixel(Node):
 
 
 def is_pixel_valid(width: int, height: int, pixel: list[int, int]) -> bool:
+    """Check if the pixel coordinates are valid within the image dimensions.
+
+    Args:
+        width (int): The width of the image.
+        height (int): The height of the image.
+        pixel (list[int, int]): The pixel coordinates to validate.
+
+    Returns:
+        bool: True if the pixel is valid, False otherwise.
+    """
     valid = True
     if not 0 <= pixel[0] < width:
         ros_logger.warn(f"Pixel x={pixel[0]} while image width={width}.")
@@ -63,7 +91,14 @@ def is_pixel_valid(width: int, height: int, pixel: list[int, int]) -> bool:
 
 
 def calculate_intrinsics(camera_info: CameraInfo) -> rs2.intrinsics:
-    """Calculate camera intrinsics for translating image to world coordinates."""
+    """Calculate camera intrinsics for translating image to world coordinates.
+
+    Args:
+        camera_info (CameraInfo): The camera information containing intrinsic parameters.
+
+    Returns:
+        rs2.intrinsics: The calculated intrinsics for the camera.
+    """
     intrinsics = rs2.intrinsics()
 
     intrinsics.width = camera_info.width
@@ -84,6 +119,11 @@ def calculate_intrinsics(camera_info: CameraInfo) -> rs2.intrinsics:
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the ROS 2 node and spin it.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     node = PoseFromPixel()
     spin_node(node)

--- a/ros2_ws/src/rcdt_detection/src_py/publish_image.py
+++ b/ros2_ws/src/rcdt_detection/src_py/publish_image.py
@@ -15,11 +15,31 @@ ros_logger = logging.get_logger(__name__)
 
 
 class PublishImage(Node):
+    """Node to publish an image to a specified topic.
+
+    This node provides a service that takes an image and a topic name,
+    and publishes the image to that topic.
+
+    Attributes:
+        node_name (str): The name of the node.
+        service_name (str): The name of the service provided by this node.
+    """
+
     def __init__(self) -> None:
+        """Initialize the PublishImage node."""
         super().__init__("publish_image")
         self.create_service(Srv, "/publish_image", self.callback)
 
     def callback(self, request: Srv.Request, response: Srv.Response) -> Srv.Response:
+        """Callback function to handle the service request.
+
+        Args:
+            request (Srv.Request): The request containing the image and topic name.
+            response (Srv.Response): The response to be filled with success status.
+
+        Returns:
+            Srv.Response: The response indicating whether the image was published successfully.
+        """
         publisher = self.create_publisher(Image, request.topic, 10)
         publisher.publish(request.image)
         response.success = True
@@ -27,6 +47,11 @@ class PublishImage(Node):
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the ROS 2 node and spin it.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     node = PublishImage()
     spin_node(node)

--- a/ros2_ws/src/rcdt_detection/src_py/publish_masks.py
+++ b/ros2_ws/src/rcdt_detection/src_py/publish_masks.py
@@ -17,11 +17,32 @@ ros_logger = logging.get_logger(__name__)
 
 
 class PublishMasks(Node):
+    """Node to publish combined masks to a specified topic.
+
+    This node provides a service that takes a list of masks and a topic name,
+    combines the masks by taking the maximum value across all masks, and publishes
+    the combined mask to the specified topic.
+
+    Attributes:
+        node_name (str): The name of the node.
+        service_name (str): The name of the service provided by this node.
+    """
+
     def __init__(self) -> None:
+        """Initialize the PublishMasks node."""
         super().__init__("publish_masks")
         self.create_service(Srv, "/publish_masks", self.callback)
 
     def callback(self, request: Srv.Request, response: Srv.Response) -> Srv.Response:
+        """Callback function to handle the service request.
+
+        Args:
+            request (Srv.Request): The request containing the list of masks and the topic name.
+            response (Srv.Response): The response to be filled with success status.
+
+        Returns:
+            Srv.Response: The response indicating whether the masks were published successfully.
+        """
         publisher = self.create_publisher(Image, request.topic, 10)
         masks_cv2 = [ros_image_to_cv2_image(mask) for mask in request.masks]
         if len(masks_cv2) == 0:
@@ -34,6 +55,11 @@ class PublishMasks(Node):
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the ROS 2 node and spin it.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     node = PublishMasks()
     spin_node(node)

--- a/ros2_ws/src/rcdt_detection/src_py/segment_image.py
+++ b/ros2_ws/src/rcdt_detection/src_py/segment_image.py
@@ -21,7 +21,18 @@ ros_logger = logging.get_logger(__name__)
 
 
 class SegmentImage(Node):
+    """Node to segment an image using a segmentation model.
+
+    This node provides a service that takes an input image, applies segmentation,
+    and returns the segmented image along with individual masks for each segment.
+
+    Attributes:
+        node_name (str): The name of the node.
+        service_name (str): The name of the service provided by this node.
+    """
+
     def __init__(self) -> None:
+        """Initialize the SegmentImage node."""
         super().__init__("segment_image")
         self.declare_parameter("model_name", "SAM2")
         model_name = self.get_parameter("model_name").get_parameter_value().string_value
@@ -29,6 +40,15 @@ class SegmentImage(Node):
         self.model = load_segmentation_model(model_name)
 
     def callback(self, request: Srv.Request, response: Srv.Response) -> Srv.Response:
+        """Callback function to handle the service request.
+
+        Args:
+            request (Srv.Request): The request containing the input image.
+            response (Srv.Response): The response to be filled with the segmented image and masks.
+
+        Returns:
+            Srv.Response: The response containing the segmented image and masks.
+        """
         input_image_ros = request.input_image
         input_image_cv2 = ros_image_to_cv2_image(input_image_ros)
 
@@ -51,6 +71,11 @@ class SegmentImage(Node):
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the ROS 2 node and spin it.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     node = SegmentImage()
     spin_node(node)

--- a/ros2_ws/src/rcdt_detection/src_py/select_image_from_list.py
+++ b/ros2_ws/src/rcdt_detection/src_py/select_image_from_list.py
@@ -14,11 +14,31 @@ ros_logger = logging.get_logger(__name__)
 
 
 class SelectImageFromList(Node):
+    """Node to select an image from a list of images.
+
+    This node provides a service that allows the selection of an image from a list
+    based on an index provided in the request.
+
+    Attributes:
+        node_name (str): The name of the node.
+        service_name (str): The name of the service provided by this node.
+    """
+
     def __init__(self) -> None:
+        """Initialize the SelectImageFromList node."""
         super().__init__("select_image_from_list")
         self.create_service(Srv, "/select_image_from_list", self.callback)
 
     def callback(self, request: Srv.Request, response: Srv.Response) -> Srv.Response:
+        """Callback function to handle the service request.
+
+        Args:
+            request (Srv.Request): The request containing the list of images and the index to select.
+            response (Srv.Response): The response to be filled with the selected image.
+
+        Returns:
+            Srv.Response: The response containing the selected image and success status.
+        """
         n_images = len(request.image_list)
         n_select = request.n
         if n_select >= n_images:
@@ -33,6 +53,11 @@ class SelectImageFromList(Node):
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the ROS 2 node and spin it.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     node = SelectImageFromList()
     spin_node(node)

--- a/ros2_ws/src/rcdt_detection/src_py/select_image_from_list.py
+++ b/ros2_ws/src/rcdt_detection/src_py/select_image_from_list.py
@@ -29,7 +29,8 @@ class SelectImageFromList(Node):
         super().__init__("select_image_from_list")
         self.create_service(Srv, "/select_image_from_list", self.callback)
 
-    def callback(self, request: Srv.Request, response: Srv.Response) -> Srv.Response:
+    @staticmethod
+    def callback(request: Srv.Request, response: Srv.Response) -> Srv.Response:
         """Callback function to handle the service request.
 
         Args:

--- a/ros2_ws/src/rcdt_detection/src_py/select_pick_location.py
+++ b/ros2_ws/src/rcdt_detection/src_py/select_pick_location.py
@@ -38,7 +38,8 @@ class SelectPickLocation(Node):
         super().__init__("filter_masks")
         self.create_service(Srv, "/select_pick_location", self.callback)
 
-    def callback(self, request: Srv.Request, response: Srv.Response) -> Srv.Response:
+    @staticmethod
+    def callback(request: Srv.Request, response: Srv.Response) -> Srv.Response:
         """Callback function to handle the service request.
 
         Args:

--- a/ros2_ws/src/rcdt_detection/src_py/select_pick_location.py
+++ b/ros2_ws/src/rcdt_detection/src_py/select_pick_location.py
@@ -22,11 +22,32 @@ logger = logging.get_logger(__name__)
 
 
 class SelectPickLocation(Node):
+    """Node to select a pick location based on depth image and masks.
+
+    This node provides a service that processes masks and depth images to determine
+    the best pick location. It uses the MaskProperties class to analyze each mask
+    and returns the most suitable pick location based on the refined mask properties.
+
+    Attributes:
+        node_name (str): The name of the node.
+        service_name (str): The name of the service provided by this node.
+    """
+
     def __init__(self) -> None:
+        """Initialize the SelectPickLocation node."""
         super().__init__("filter_masks")
         self.create_service(Srv, "/select_pick_location", self.callback)
 
     def callback(self, request: Srv.Request, response: Srv.Response) -> Srv.Response:
+        """Callback function to handle the service request.
+
+        Args:
+            request (Srv.Request): The request containing the depth image and masks.
+            response (Srv.Response): The response to be filled with the pick location and visualization.
+
+        Returns:
+            Srv.Response: The response containing the pick location and visualization.
+        """
         depth_image = ros_image_to_cv2_image(request.depth_image)
         intrinsics = camera_info_to_intrinsics(request.camera_info)
         pickup_poses: list[Pose] = []
@@ -61,6 +82,11 @@ class SelectPickLocation(Node):
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the ROS 2 node and spin it.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     node = SelectPickLocation()
     spin_node(node)

--- a/ros2_ws/src/rcdt_detection/src_py/select_place_location.py
+++ b/ros2_ws/src/rcdt_detection/src_py/select_place_location.py
@@ -17,7 +17,20 @@ logger = logging.get_logger(__name__)
 
 
 class SelectPlaceLocation(Node):
+    """Node to select a place location based on a triangular grid.
+
+    This node provides a service that calculates place locations in a triangular grid
+    pattern. It starts from a base layer and moves upwards, adjusting the x and y
+    coordinates based on the current layer and row index. The pose is returned in a
+    ROS-compatible format.
+
+    Attributes:
+        node_name (str): The name of the node.
+        service_name (str): The name of the service provided by this node.
+    """
+
     def __init__(self) -> None:
+        """Initialize the SelectPlaceLocation node."""
         super().__init__("place_locations")
         self.create_service(Srv, "/select_place_location", self.callback)
         self.brick_height = 0.07
@@ -28,6 +41,15 @@ class SelectPlaceLocation(Node):
         self.row_idx = 0
 
     def callback(self, _request: Srv.Request, response: Srv.Response) -> Srv.Response:
+        """Callback function to handle the service request.
+
+        Args:
+            _request (Srv.Request): The request object (not used in this implementation).
+            response (Srv.Response): The response to be filled with the place location.
+
+        Returns:
+            Srv.Response: The response containing the place location and success status.
+        """
         if self.layer >= self.base_layer_size:
             response.success = False
             logger.error("out of triangle layers")
@@ -60,6 +82,11 @@ class SelectPlaceLocation(Node):
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the ROS 2 node and spin it.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     node = SelectPlaceLocation()
     spin_node(node)

--- a/ros2_ws/src/rcdt_franka/launch/controllers.launch.py
+++ b/ros2_ws/src/rcdt_franka/launch/controllers.launch.py
@@ -18,6 +18,9 @@ def launch_setup(context: LaunchContext) -> list:
 
     Args:
         context (LaunchContext): The launch context.
+
+    Returns:
+        list: A list of actions to be executed in the launch description.
     """
     simulation = simulation_arg.bool_value(context)
 

--- a/ros2_ws/src/rcdt_franka/launch/controllers.launch.py
+++ b/ros2_ws/src/rcdt_franka/launch/controllers.launch.py
@@ -14,6 +14,11 @@ gripper_config = get_file_path("franka_gripper", ["config"], "franka_gripper_nod
 
 
 def launch_setup(context: LaunchContext) -> None:
+    """Setup the launch description for the Franka controllers.
+
+    Args:
+        context (LaunchContext): The launch context.
+    """
     simulation = simulation_arg.value(context)
 
     namespace = "franka"
@@ -72,6 +77,11 @@ def launch_setup(context: LaunchContext) -> None:
 
 
 def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for the Franka controllers.
+
+    Returns:
+        LaunchDescription: The launch description containing the nodes and actions.
+    """
     return LaunchDescription(
         [
             simulation_arg.declaration,

--- a/ros2_ws/src/rcdt_franka/launch/core.launch.py
+++ b/ros2_ws/src/rcdt_franka/launch/core.launch.py
@@ -21,6 +21,11 @@ use_realsense_arg = LaunchArgument("realsense", False, [True, False])
 
 
 def launch_setup(context: LaunchContext) -> None:
+    """Setup the launch description for the Franka core.
+
+    Args:
+        context (LaunchContext): The launch context.
+    """
     use_sim = use_sim_arg.value(context)
     parent = parent_arg.value(context)
     load_gazebo_ui = load_gazebo_ui_arg.value(context)
@@ -85,6 +90,11 @@ def launch_setup(context: LaunchContext) -> None:
 
 
 def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for the Franka core.
+
+    Returns:
+        LaunchDescription: The launch description for the Franka core.
+    """
     return LaunchDescription(
         [
             use_sim_arg.declaration,

--- a/ros2_ws/src/rcdt_franka/launch/franka.launch.py
+++ b/ros2_ws/src/rcdt_franka/launch/franka.launch.py
@@ -22,6 +22,9 @@ def launch_setup(context: LaunchContext) -> list:
 
     Args:
         context (LaunchContext): The launch context.
+
+    Returns:
+        list: A list of actions to be executed in the launch description.
     """
     use_sim = use_sim_arg.bool_value(context)
     load_gazebo_ui = load_gazebo_ui_arg.bool_value(context)

--- a/ros2_ws/src/rcdt_franka/launch/franka.launch.py
+++ b/ros2_ws/src/rcdt_franka/launch/franka.launch.py
@@ -18,6 +18,11 @@ use_realsense_arg = LaunchArgument("realsense", False, [True, False])
 
 
 def launch_setup(context: LaunchContext) -> None:
+    """Setup the launch description for the Franka robot.
+
+    Args:
+        context (LaunchContext): The launch context.
+    """
     use_sim = use_sim_arg.value(context)
     load_gazebo_ui = load_gazebo_ui_arg.value(context)
     use_rviz = use_rviz_arg.value(context)
@@ -94,6 +99,11 @@ def launch_setup(context: LaunchContext) -> None:
 
 
 def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for the Franka robot.
+
+    Returns:
+        LaunchDescription: The launch description for the Franka robot.
+    """
     return LaunchDescription(
         [
             use_sim_arg.declaration,

--- a/ros2_ws/src/rcdt_franka/launch/gripper_services.launch.py
+++ b/ros2_ws/src/rcdt_franka/launch/gripper_services.launch.py
@@ -9,6 +9,11 @@ from rcdt_utilities.register import Register
 
 
 def launch_setup(context: LaunchContext) -> None:
+    """Setup the launch description for the Franka gripper services.
+
+    Args:
+        context (LaunchContext): The launch context.
+    """
     namespace = "franka"
 
     open_gripper = Node(
@@ -29,4 +34,9 @@ def launch_setup(context: LaunchContext) -> None:
 
 
 def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for the Franka gripper services.
+
+    Returns:
+        LaunchDescription: The launch description containing the gripper services.
+    """
     return LaunchDescription([OpaqueFunction(function=launch_setup)])

--- a/ros2_ws/src/rcdt_franka/launch/gripper_services.launch.py
+++ b/ros2_ws/src/rcdt_franka/launch/gripper_services.launch.py
@@ -13,6 +13,9 @@ def launch_setup(context: LaunchContext) -> list:
 
     Args:
         context (LaunchContext): The launch context.
+
+    Returns:
+        list: A list of actions to be executed in the launch description.
     """
     namespace = "franka"
 

--- a/ros2_ws/src/rcdt_franka/launch/robot.launch.py
+++ b/ros2_ws/src/rcdt_franka/launch/robot.launch.py
@@ -52,6 +52,11 @@ joint_state_publisher = Node(
 
 
 def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for the Franka robot controllers.
+
+    Returns:
+        LaunchDescription: The launch description containing the Franka controllers.
+    """
     return LaunchDescription(
         [
             settings_setter,

--- a/ros2_ws/src/rcdt_franka/rcdt_franka/test/conftest.py
+++ b/ros2_ws/src/rcdt_franka/rcdt_franka/test/conftest.py
@@ -10,7 +10,11 @@ from rcdt_utilities.register import RegisteredLaunchDescription
 
 @pytest.fixture(scope="module")
 def controllers_launch() -> RegisteredLaunchDescription:
-    """Fixture to create launch file for controllers."""
+    """Fixture to create launch file for controllers.
+
+    Returns:
+        RegisteredLaunchDescription: The launch description for the controllers.
+    """
     return RegisteredLaunchDescription(
         get_file_path("rcdt_franka", ["launch"], "controllers.launch.py")
     )
@@ -18,7 +22,11 @@ def controllers_launch() -> RegisteredLaunchDescription:
 
 @pytest.fixture(scope="module")
 def core_launch() -> RegisteredLaunchDescription:
-    """Fixture to create launch file for the franka core."""
+    """Fixture to create launch file for the franka core.
+
+    Returns:
+        RegisteredLaunchDescription: The launch description for the franka core.
+    """
     return RegisteredLaunchDescription(
         get_file_path("rcdt_franka", ["launch"], "core.launch.py")
     )
@@ -26,7 +34,11 @@ def core_launch() -> RegisteredLaunchDescription:
 
 @pytest.fixture(scope="module")
 def moveit_launch() -> RegisteredLaunchDescription:
-    """Fixture to launch moveit."""
+    """Fixture to launch moveit.
+
+    Returns:
+        RegisteredLaunchDescription: The launch description for MoveIt.
+    """
     return RegisteredLaunchDescription(
         get_file_path("rcdt_moveit", ["launch"], "moveit.launch.py"),
         launch_arguments={
@@ -40,7 +52,11 @@ def moveit_launch() -> RegisteredLaunchDescription:
 
 @pytest.fixture(scope="module")
 def gripper_services_launch() -> RegisteredLaunchDescription:
-    """Fixture to create launch file for controllers."""
+    """Fixture to create launch file for controllers.
+
+    Returns:
+        RegisteredLaunchDescription: The launch description for the gripper services.
+    """
     return RegisteredLaunchDescription(
         get_file_path("rcdt_franka", ["launch"], "gripper_services.launch.py")
     )

--- a/ros2_ws/src/rcdt_franka/rcdt_franka/test/end_to_end/base_franka.py
+++ b/ros2_ws/src/rcdt_franka/rcdt_franka/test/end_to_end/base_franka.py
@@ -18,20 +18,40 @@ from sensor_msgs.msg import JointState, Joy
 
 
 def get_tests() -> dict:
-    """Test class for the Franka robot."""
+    """Test class for the Franka robot.
+
+    Returns:
+        dict: A dictionary containing the test methods.
+    """
 
     def test_wait_for_register(_self: object, timeout: int) -> None:
+        """Test that the robot is registered in the system to start the tests.
+
+        Args:
+            _self (object): The test class instance.
+            timeout (int): The timeout in seconds to wait for the robot to register.
+        """
         wait_for_register(timeout=timeout)
 
     def test_joint_states_published(_self: object, timeout: int) -> None:
-        """Test that joint states are published. This is a basic test to check that the
-        launch file is working and that the robot is publishing joint states."""
+        """Test that joint states are published.
+
+        Args:
+            _self (object): The test class instance.
+            timeout (int): The timeout in seconds to wait for the joint states to be published.
+        """
         assert_for_message(JointState, "franka/joint_states", timeout=timeout)
 
     def test_switch_joy_to_franka_topic(
         _self: object, test_node: Node, timeout: int
     ) -> None:
-        """Test to see if the switch to Franka mode is correct."""
+        """Test to see if the switch to Franka mode is correct.
+
+        Args:
+            _self (object): The test class instance.
+            test_node (Node): The test node to use for the test.
+            timeout (int): The timeout in seconds to wait for the joy topic to switch.
+        """
         assert_joy_topic_switch(
             node=test_node,
             expected_topic="/franka/joy",
@@ -54,12 +74,16 @@ def get_tests() -> dict:
         finger_joint_fault_tolerance: float,
         timeout: int,
     ) -> None:
-        """Test that the joy node is running and the gripper is moving.
-        The first call is an initialization call.
-        The second call is a call to open the gripper.
-        The third call is a call to close the gripper.
-        """
+        """Test the gripper node with the joystick.
 
+        Args:
+            _self (object): The test class instance.
+            buttons (list[int]): The button configuration to use for the test.
+            expected_value (float): The expected value of the finger joint after the test.
+            test_node (Node): The test node to use for the test.
+            finger_joint_fault_tolerance (float): The tolerance for the finger joint fault.
+            timeout (int): The timeout in seconds to wait for the gripper node to respond.
+        """
         pub = test_node.create_publisher(Joy, "/joy", 10)
         wait_for_subscriber(pub, timeout)
 
@@ -94,10 +118,27 @@ def get_tests() -> dict:
         timeout: int,
         movement_threshold: float = 0.01,
     ) -> None:
-        """Tests the linear movements of the hand while controlling with the joystick.
-        Assert if it moves above a certain movement_threshold."""
+        """Test moving the arm with the joystick.
+
+        Args:
+            _self (object): The test class instance.
+            axes (list[float]): The joystick axes to use for the test.
+            direction (str): The direction to move the arm in ("x", "y", or "z").
+            test_node (Node): The test node to use for the test.
+            timeout (int): The timeout in seconds to wait for the arm to move.
+            movement_threshold (float): The threshold for movement detection.
+        """
 
         def compare_fn(p1: Pose, p2: Pose) -> float:
+            """Compare the positions of two poses based on the specified direction.
+
+            Args:
+                p1 (Pose): The first pose to compare.
+                p2 (Pose): The second pose to compare.
+
+            Returns:
+                float: The difference in the specified direction between the two poses.
+            """
             return getattr(p2.position, direction) - getattr(p1.position, direction)
 
         assert_movements_with_joy(
@@ -121,5 +162,9 @@ def get_tests() -> dict:
 
 
 def FrankaTestSuite() -> object:  # noqa: N802
-    """Dynamically create a test class with the test methods."""
+    """Create a test suite for the Franka robot.
+
+    Returns:
+        object: A class containing the test methods for the Franka robot.
+    """
     return type("FrankaFullTests", (), get_tests())

--- a/ros2_ws/src/rcdt_franka/rcdt_franka/test/end_to_end/test_franka.py
+++ b/ros2_ws/src/rcdt_franka/rcdt_franka/test/end_to_end/test_franka.py
@@ -13,6 +13,15 @@ from rcdt_utilities.register import Register, RegisteredLaunchDescription
 
 @launch_pytest.fixture(scope="class")
 def franka() -> LaunchDescription:
+    """Fixture to create a launch description for the Franka robot.
+
+    This fixture sets up the Franka robot with the necessary configurations and
+    launches the required nodes for testing.
+
+    Returns:
+        LaunchDescription: The launch description containing the Franka robot setup.
+
+    """
     franka_launch = RegisteredLaunchDescription(
         get_file_path("rcdt_franka", ["launch"], "franka.launch.py"),
         launch_arguments={
@@ -26,4 +35,8 @@ def franka() -> LaunchDescription:
 
 @pytest.mark.launch(fixture=franka)
 class TestCoreLaunch(FrankaTestSuite()):
-    """Run all the FrankaLaunchTests under franka.launch.py"""
+    """Test suite for the Franka robot using the core launch file.
+
+    This class inherits from FrankaTestSuite and runs all tests defined in the base class.
+    It uses the `franka` fixture to set up the launch description for the Franka robot.
+    """

--- a/ros2_ws/src/rcdt_franka/rcdt_franka/test/integration/test_franka_core.py
+++ b/ros2_ws/src/rcdt_franka/rcdt_franka/test/integration/test_franka_core.py
@@ -19,16 +19,35 @@ def franka_core_launch(
     core_launch: RegisteredLaunchDescription,
     controllers_launch: RegisteredLaunchDescription,
 ) -> LaunchDescription:
+    """Fixture to create launch file for the franka core and controllers.
+
+    Args:
+        core_launch (RegisteredLaunchDescription): The launch description for the core.
+        controllers_launch (RegisteredLaunchDescription): The launch description for the controllers.
+
+    Returns:
+        LaunchDescription: The launch description for the franka core and controllers.
+    """
     return Register.connect_context([core_launch, controllers_launch])
 
 
 @pytest.mark.launch(fixture=franka_core_launch)
 def test_wait_for_register(timeout: int) -> None:
+    """Test that the robot is registered in the system to start the tests.
+
+    Args:
+        timeout (int): The timeout in seconds to wait for the robot to register.
+    """
     wait_for_register(timeout=timeout)
 
 
 @pytest.mark.launch(fixture=franka_core_launch)
 def test_joint_states_published(timeout: int) -> None:
+    """Test that joint states are published.
+
+    Args:
+        timeout (int): The timeout in seconds to wait for the joint states to be published.
+    """
     assert_for_message(JointState, "franka/joint_states", timeout=timeout)
 
 
@@ -36,6 +55,13 @@ def test_joint_states_published(timeout: int) -> None:
 def test_follow_joint_trajectory_goal(
     test_node: Node, joint_movement_tolerance: float, timeout: int
 ) -> None:
+    """Test following a joint trajectory goal.
+
+    Args:
+        test_node (Node): The test node to use for the test.
+        joint_movement_tolerance (float): The tolerance for joint movement.
+        timeout (int): The timeout in seconds to wait for the joint trajectory goal to be followed.
+    """
     follow_joint_trajectory_goal(
         test_node,
         positions=[0.0, -0.5, 0.5, 0.0, 0.0, 0.0, 0.0],

--- a/ros2_ws/src/rcdt_franka/rcdt_franka/test/integration/test_franka_gripper.py
+++ b/ros2_ws/src/rcdt_franka/rcdt_franka/test/integration/test_franka_gripper.py
@@ -23,6 +23,16 @@ def franka_and_gripper_launch(
     controllers_launch: RegisteredLaunchDescription,
     gripper_services_launch: RegisteredLaunchDescription,
 ) -> LaunchDescription:
+    """Fixture to create launch file for the franka core, controllers, and gripper services.
+
+    Args:
+        core_launch (RegisteredLaunchDescription): The launch description for the core.
+        controllers_launch (RegisteredLaunchDescription): The launch description for the controllers.
+        gripper_services_launch (RegisteredLaunchDescription): The launch description for the gripper services.
+
+    Returns:
+        LaunchDescription: The launch description for the franka core, controllers, and gripper services.
+    """
     return Register.connect_context(
         [core_launch, controllers_launch, gripper_services_launch]
     )
@@ -30,11 +40,21 @@ def franka_and_gripper_launch(
 
 @pytest.mark.launch(fixture=franka_and_gripper_launch)
 def test_wait_for_register(timeout: int) -> None:
+    """Test that the robot is registered in the system to start the tests.
+
+    Args:
+        timeout (int): The timeout in seconds before stopping the test.
+    """
     wait_for_register(timeout=timeout)
 
 
 @pytest.mark.launch(fixture=franka_and_gripper_launch)
 def test_joint_states_published(timeout: int) -> None:
+    """Test that joint states are published.
+
+    Args:
+        timeout (int): The timeout in seconds before stopping the test.
+    """
     assert_for_message(JointState, "franka/joint_states", timeout=timeout)
 
 
@@ -53,7 +73,15 @@ def test_gripper_action(
     finger_joint_fault_tolerance: float,
     timeout: int,
 ) -> None:
-    """Test gripper open/close action and verify joint state."""
+    """Test gripper open/close action and verify joint state.
+
+    Args:
+        service (str): The service to call for the gripper action.
+        expected_value (float): The expected joint value after the action.
+        test_node (Node): The test node to use for the test.
+        finger_joint_fault_tolerance (float): The tolerance for the finger joint position.
+        timeout (int): The timeout in seconds before stopping the test.
+    """
     assert call_trigger_service(test_node, service, timeout=timeout) is True
     joint_value = get_joint_position(
         namespace="franka", joint="fr3_finger_joint1", timeout=timeout

--- a/ros2_ws/src/rcdt_franka/rcdt_franka/test/integration/test_franka_moveit.py
+++ b/ros2_ws/src/rcdt_franka/rcdt_franka/test/integration/test_franka_moveit.py
@@ -20,16 +20,36 @@ def franka_and_moveit_launch(
     controllers_launch: RegisteredLaunchDescription,
     moveit_launch: RegisteredLaunchDescription,
 ) -> LaunchDescription:
+    """Fixture to create launch file for the franka core, controllers, and MoveIt.
+
+    Args:
+        core_launch (RegisteredLaunchDescription): The launch description for the core.
+        controllers_launch (RegisteredLaunchDescription): The launch description for the controllers.
+        moveit_launch (RegisteredLaunchDescription): The launch description for MoveIt.
+
+    Returns:
+        LaunchDescription: The launch description for the franka core, controllers, and MoveIt.
+    """
     return Register.connect_context([core_launch, controllers_launch, moveit_launch])
 
 
 @pytest.mark.launch(fixture=franka_and_moveit_launch)
 def test_wait_for_register(timeout: int) -> None:
+    """Test that the robot is registered in the system to start the tests.
+
+    Args:
+        timeout (int): The timeout in seconds before stopping the test.
+    """
     wait_for_register(timeout=timeout)
 
 
 @pytest.mark.launch(fixture=franka_and_moveit_launch)
 def test_joint_states_published(timeout: int) -> None:
+    """Test that joint states are published.
+
+    Args:
+        timeout (int): The timeout in seconds before stopping the test.
+    """
     assert_for_message(JointState, "franka/joint_states", timeout=timeout)
 
 
@@ -37,8 +57,13 @@ def test_joint_states_published(timeout: int) -> None:
 def test_move_to_drop_configuration(
     test_node: Node, joint_movement_tolerance: float, timeout: int
 ) -> None:
-    """Test that MoveIt can move to a configuration."""
+    """Test that MoveIt can move to a configuration.
 
+    Args:
+        test_node (Node): The test node to use for the test.
+        joint_movement_tolerance (float): The tolerance for joint movement.
+        timeout (int): The timeout in seconds before stopping the test.
+    """
     assert (
         call_move_to_configuration_service(test_node, "drop", timeout=timeout) is True
     )

--- a/ros2_ws/src/rcdt_franka/rcdt_franka/test/utils.py
+++ b/ros2_ws/src/rcdt_franka/rcdt_franka/test/utils.py
@@ -6,7 +6,7 @@
 import rclpy
 from builtin_interfaces.msg import Duration
 from control_msgs.action import FollowJointTrajectory
-from rcdt_messages.srv._move_to_configuration import MoveToConfiguration
+from rcdt_messages.srv import MoveToConfiguration
 from rcdt_utilities.test_utils import (
     create_ready_action_client,
     create_ready_service_client,

--- a/ros2_ws/src/rcdt_franka/rcdt_franka/test/utils.py
+++ b/ros2_ws/src/rcdt_franka/rcdt_franka/test/utils.py
@@ -20,7 +20,16 @@ from trajectory_msgs.msg import JointTrajectoryPoint
 def call_move_to_configuration_service(
     node: Node, configuration: str, timeout: int
 ) -> bool:
-    """Call the move_to_configuration service and return True if a response from the service was received."""
+    """Call the move_to_configuration service and return True if a response from the service was received.
+
+    Args:
+        node (Node): The ROS 2 node to use for the service call.
+        configuration (str): The configuration to move to.
+        timeout (int): The timeout in seconds for the service call.
+
+    Returns:
+        bool: True if the service call was successful, False otherwise.
+    """
     client = create_ready_service_client(
         node,
         MoveToConfiguration,
@@ -41,8 +50,15 @@ def follow_joint_trajectory_goal(
     timeout: int,
     time_from_start: int = 3,
 ) -> None:
-    """Test sending a joint trajectory goal to the arm controller."""
+    """Test sending a joint trajectory goal to the arm controller.
 
+    Args:
+        node (Node): The ROS 2 node to use for the action client.
+        positions (list[float]): The joint positions to move to.
+        controller (str): The name of the controller to use.
+        timeout (int): The timeout in seconds for the action client.
+        time_from_start (int, optional): The time from start in seconds. Defaults to 3.
+    """
     action_client = create_ready_action_client(
         node,
         FollowJointTrajectory,

--- a/ros2_ws/src/rcdt_franka/src_py/close_gripper.py
+++ b/ros2_ws/src/rcdt_franka/src_py/close_gripper.py
@@ -18,7 +18,10 @@ ros_logger = logging.get_logger(__name__)
 
 
 class CloseGripper(Node):
+    """Node to close the gripper using the Grasp action from franka_msgs."""
+
     def __init__(self) -> None:
+        """Initialize the CloseGripper node."""
         super().__init__("close_gripper")
 
         cbg_service = MutuallyExclusiveCallbackGroup()
@@ -34,6 +37,10 @@ class CloseGripper(Node):
         self.create_goal()
 
     def create_goal(self) -> None:
+        """Create the goal for the Grasp action.
+
+        This method initializes the goal with default values for width, epsilon, force, and speed.
+        """
         self.goal = Grasp.Goal()
         self.goal.width = 0.0
         self.goal.epsilon.inner = self.goal.epsilon.outer = 0.08
@@ -43,10 +50,24 @@ class CloseGripper(Node):
     def callback(
         self, _request: Trigger.Request, response: Trigger.Response
     ) -> Trigger.Response:
+        """Callback for the close_gripper service.
+
+        Args:
+            _request (Trigger.Request): The request for the service.
+            response (Trigger.Response): The response to be filled.
+
+        Returns:
+            Trigger.Response: The response indicating success or failure of the gripper closing operation.
+        """
         response.success = self.close_gripper()
         return response
 
     def close_gripper(self) -> bool:
+        """Close the gripper using the Grasp action.
+
+        Returns:
+            bool: True if the gripper was closed successfully, False otherwise.
+        """
         if not self.client.wait_for_server(timeout_sec=3):
             self.get_logger().error("Gripper grasp client not available.")
             return False
@@ -58,6 +79,11 @@ class CloseGripper(Node):
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the CloseGripper node and start the executor.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     executor = MultiThreadedExecutor()
     node = CloseGripper()

--- a/ros2_ws/src/rcdt_franka/src_py/franka_gripper_simulation.py
+++ b/ros2_ws/src/rcdt_franka/src_py/franka_gripper_simulation.py
@@ -17,13 +17,24 @@ MIN = 0.001
 
 
 class GripperActionControllerClient(Node):
+    """Client for the Gripper Action Controller."""
+
     def __init__(self):
+        """Initialize the Gripper Action Controller Client."""
         super().__init__("gripper_action_controller_client")
         self.client = ActionClient(
             self, GripperCommand, "/franka/gripper_action_controller/gripper_cmd"
         )
 
     def move(self, width: float) -> bool:
+        """Move the gripper to a specified width.
+
+        Args:
+            width (float): The desired width to move the gripper to.
+
+        Returns:
+            bool: True if the gripper reached the goal, False otherwise.
+        """
         goal = GripperCommand.Goal()
         goal.command.position = self.respect_limits(width)
         self.client.wait_for_server()
@@ -32,6 +43,15 @@ class GripperActionControllerClient(Node):
         return result.result.reached_goal
 
     def grasp(self, width: float, max_effort: float) -> bool:
+        """Grasp with the gripper at a specified width and maximum effort.
+
+        Args:
+            width (float): The desired width to grasp.
+            max_effort (float): The maximum effort to apply during the grasp.
+
+        Returns:
+            bool: True if the gripper reached the goal or stalled, False otherwise.
+        """
         goal = GripperCommand.Goal()
         goal.command.position = self.respect_limits(width)
         goal.command.max_effort = max_effort
@@ -41,11 +61,26 @@ class GripperActionControllerClient(Node):
         return result.result.reached_goal or result.result.stalled
 
     def respect_limits(self, width: float) -> float:
+        """Ensure the gripper width is within the defined limits.
+
+        Args:
+            width (float): The desired width to set for the gripper.
+
+        Returns:
+            float: The width adjusted to be within the limits defined by MIN and MAX.
+        """
         return min(MAX, max(MIN, width))
 
 
 class FrankaGripperSimulation(Node):
+    """Node to simulate the Franka Gripper using action servers."""
+
     def __init__(self, gripper_action_controller_client: GripperActionControllerClient):
+        """Initialize the Franka Gripper Simulation node.
+
+        Args:
+            gripper_action_controller_client (GripperActionControllerClient): The client to interact with the gripper action controller.
+        """
         super().__init__("fr3_gripper")
         self.gripper_action_client = gripper_action_controller_client
         ActionServer(self, Grasp, "~/grasp", self.grasp_action)
@@ -53,6 +88,14 @@ class FrankaGripperSimulation(Node):
         ActionServer(self, Move, "~/move", self.move_action)
 
     def grasp_action(self, goal_handle: ServerGoalHandle) -> Grasp.Result:
+        """Handle the Grasp action request.
+
+        Args:
+            goal_handle (ServerGoalHandle): The handle for the goal.
+
+        Returns:
+            Grasp.Result: The result of the grasp action, indicating success or failure.
+        """
         self.get_logger().info("Gripper Grasping...")
         request: Grasp.Goal = goal_handle.request
         result = Grasp.Result()
@@ -63,6 +106,14 @@ class FrankaGripperSimulation(Node):
         return result
 
     def homing_action(self, goal_handle: ServerGoalHandle) -> Homing.Result:
+        """Handle the Homing action request.
+
+        Args:
+            goal_handle (ServerGoalHandle): The handle for the goal.
+
+        Returns:
+            Homing.Result: The result of the homing action, indicating success or failure.
+        """
         self.get_logger().info("Gripper Homing...")
         result = Homing.Result()
         if self.gripper_action_client.move(MAX):
@@ -72,6 +123,14 @@ class FrankaGripperSimulation(Node):
         return result
 
     def move_action(self, goal_handle: ServerGoalHandle) -> Move.Result:
+        """Handle the Move action request.
+
+        Args:
+            goal_handle (ServerGoalHandle): The handle for the goal.
+
+        Returns:
+            Move.Result: The result of the move action, indicating success or failure.
+        """
         self.get_logger().info("Gripper Moving...")
         request: Move.Goal = goal_handle.request
         result = Move.Result()
@@ -83,6 +142,11 @@ class FrankaGripperSimulation(Node):
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the ROS 2 node and start the executor.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     executor = MultiThreadedExecutor()
 

--- a/ros2_ws/src/rcdt_franka/src_py/franka_gripper_simulation.py
+++ b/ros2_ws/src/rcdt_franka/src_py/franka_gripper_simulation.py
@@ -60,7 +60,8 @@ class GripperActionControllerClient(Node):
         result: GripperCommand.Impl.GetResultService.Response
         return result.result.reached_goal or result.result.stalled
 
-    def respect_limits(self, width: float) -> float:
+    @staticmethod
+    def respect_limits(width: float) -> float:
         """Ensure the gripper width is within the defined limits.
 
         Args:

--- a/ros2_ws/src/rcdt_franka/src_py/open_gripper.py
+++ b/ros2_ws/src/rcdt_franka/src_py/open_gripper.py
@@ -18,7 +18,10 @@ ros_logger = logging.get_logger(__name__)
 
 
 class OpenGripper(Node):
+    """Node to open the gripper using the Move action from franka_msgs."""
+
     def __init__(self) -> None:
+        """Initialize the OpenGripper node."""
         super().__init__("open_gripper")
 
         cbg_service = MutuallyExclusiveCallbackGroup()
@@ -34,6 +37,7 @@ class OpenGripper(Node):
         self.create_goal()
 
     def create_goal(self) -> None:
+        """Create the goal for the Move action."""
         self.goal = Move.Goal()
         self.goal.width = 0.08
         self.goal.speed = 0.03
@@ -41,10 +45,26 @@ class OpenGripper(Node):
     def callback(
         self, _request: Trigger.Request, response: Trigger.Response
     ) -> Trigger.Response:
+        """Callback for the open_gripper service.
+
+        Args:
+            _request (Trigger.Request): The request for the service.
+            response (Trigger.Response): The response to be filled.
+
+        Returns:
+            Trigger.Response: The response indicating success or failure of the gripper opening operation.
+        """
         response.success = self.open_gripper()
         return response
 
     def open_gripper(self) -> bool:
+        """Open the gripper using the Move action.
+
+        This method sends a goal to the gripper action server to open the gripper.
+
+        Returns:
+            bool: True if the gripper opened successfully, False otherwise.
+        """
         if not self.client.wait_for_server(timeout_sec=3):
             self.get_logger().error("Gripper move client not available.")
             return False
@@ -56,6 +76,11 @@ class OpenGripper(Node):
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the OpenGripper node and start the executor.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     executor = MultiThreadedExecutor()
     node = OpenGripper()

--- a/ros2_ws/src/rcdt_franka/src_py/settings_setter.py
+++ b/ros2_ws/src/rcdt_franka/src_py/settings_setter.py
@@ -12,7 +12,10 @@ MAX_FORCES = [100.0, 100.0, 100.0, 30.0, 30.0, 30.0]
 
 
 class SettingsSetter(Node):
+    """Node to set the force and torque collision behavior for the Franka robot."""
+
     def __init__(self):
+        """Initialize the SettingsSetter node."""
         super().__init__("settings_setter")
         self.client = self.create_client(
             SetForceTorqueCollisionBehavior,
@@ -23,6 +26,14 @@ class SettingsSetter(Node):
         self.request = SetForceTorqueCollisionBehavior.Request()
 
     def set_thresholds(self) -> SetForceTorqueCollisionBehavior.Response:
+        """Set the force and torque thresholds for the Franka robot.
+
+        This method sends a request to the service to set the upper torque and force thresholds
+        to predefined maximum values.
+
+        Returns:
+            SetForceTorqueCollisionBehavior.Response: The response from the service indicating success or failure.
+        """
         self.request.upper_torque_thresholds_nominal = MAX_TORQUES
         self.request.upper_force_thresholds_nominal = MAX_FORCES
         future = self.client.call_async(self.request)
@@ -31,6 +42,11 @@ class SettingsSetter(Node):
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the ROS 2 node and set the thresholds.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     settings_setter = SettingsSetter()
     response = settings_setter.set_thresholds()

--- a/ros2_ws/src/rcdt_gazebo/launch/gazebo_robot.launch.py
+++ b/ros2_ws/src/rcdt_gazebo/launch/gazebo_robot.launch.py
@@ -75,7 +75,7 @@ def launch_setup(context: LaunchContext) -> List:
 
     spawn_robots: list[Node] = []
     for robot, position in zip(robots, positions):
-        namespace = "" if robot == "" else f"/{robot}"
+        namespace = "" if not robot else f"/{robot}"
         x, y, z = position.split("-")
         spawn_robot = Node(
             package="ros_gz_sim",

--- a/ros2_ws/src/rcdt_gazebo/launch/gazebo_robot.launch.py
+++ b/ros2_ws/src/rcdt_gazebo/launch/gazebo_robot.launch.py
@@ -22,6 +22,14 @@ use_velodyne_arg = LaunchArgument("velodyne", False, [True, False])
 
 
 def launch_setup(context: LaunchContext) -> List:
+    """Setup the launch context for the Gazebo simulation with robots.
+
+    Args:
+        context (LaunchContext): The launch context.
+
+    Returns:
+        List: A list of actions to be executed.
+    """
     load_gazebo_ui = load_gazebo_ui_arg.value(context)
     world = world_arg.value(context)
     robots = robots_arg.value(context).split(" ")
@@ -113,6 +121,11 @@ def launch_setup(context: LaunchContext) -> List:
 
 
 def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for the Gazebo simulation with robots.
+
+    Returns:
+        LaunchDescription: The launch description containing the actions to be executed.
+    """
     return LaunchDescription(
         [
             load_gazebo_ui_arg.declaration,

--- a/ros2_ws/src/rcdt_gazebo/launch/gazebo_robot.launch.py
+++ b/ros2_ws/src/rcdt_gazebo/launch/gazebo_robot.launch.py
@@ -27,6 +27,9 @@ def launch_setup(context: LaunchContext) -> List:
     Args:
         context (LaunchContext): The launch context.
 
+    Raises:
+        ValueError: If the SDF file does not contain a world attribute with a name.
+
     Returns:
         List: A list of actions to be executed in the launch description.
     """

--- a/ros2_ws/src/rcdt_gazebo/rcdt_gazebo/gazebo_ros_paths.py
+++ b/ros2_ws/src/rcdt_gazebo/rcdt_gazebo/gazebo_ros_paths.py
@@ -17,8 +17,7 @@ from ros2pkg.api import get_package_names
 
 
 class GazeboRosPaths:
-    """
-    Based on: https://github.com/gazebosim/ros_gz/blob/ros2/ros_gz_sim/launch/gz_sim.launch.py.in.
+    """Based on: https://github.com/gazebosim/ros_gz/blob/ros2/ros_gz_sim/launch/gz_sim.launch.py.in.
 
     By using our own launch file we are able to launch Gazebo as process with shell=False.
     This avoids ghost processes of Gazebo continuing and might be implemented in the original launch file in the future:
@@ -27,6 +26,11 @@ class GazeboRosPaths:
 
     @staticmethod
     def get_paths() -> tuple[str, str]:
+        """Get the paths for Gazebo models and plugins.
+
+        Returns:
+            tuple[str, str]: A tuple containing the model paths and plugin paths.
+        """
         gazebo_model_path = []
         gazebo_plugin_path = []
         gazebo_media_path = []
@@ -66,6 +70,11 @@ class GazeboRosPaths:
 
     @staticmethod
     def get_env() -> dict[str, str]:
+        """Get the environment variables for Gazebo.
+
+        Returns:
+            dict[str, str]: A dictionary containing the environment variables.
+        """
         model_paths, plugin_paths = GazeboRosPaths.get_paths()
         env = {
             "GZ_SIM_SYSTEM_PLUGIN_PATH": os.pathsep.join(

--- a/ros2_ws/src/rcdt_joystick/launch/joystick.launch.py
+++ b/ros2_ws/src/rcdt_joystick/launch/joystick.launch.py
@@ -12,6 +12,14 @@ robots_arg = LaunchArgument("robots", "")
 
 
 def launch_setup(context: LaunchContext) -> list:
+    """Setup the launch context for the joystick nodes.
+
+    Args:
+        context (LaunchContext): The launch context.
+
+    Returns:
+        list: A list of actions to be executed.
+    """
     robots = robots_arg.value(context).split(" ")
 
     joy = Node(
@@ -74,6 +82,11 @@ def launch_setup(context: LaunchContext) -> list:
 
 
 def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for the joystick nodes.
+
+    Returns:
+        LaunchDescription: The launch description containing the joystick nodes.
+    """
     return LaunchDescription(
         [
             robots_arg.declaration,

--- a/ros2_ws/src/rcdt_joystick/src_py/joy_to_gripper.py
+++ b/ros2_ws/src/rcdt_joystick/src_py/joy_to_gripper.py
@@ -17,7 +17,22 @@ from std_srvs.srv import Trigger
 
 
 class JoyToGripper(Node):
+    """A ROS2 node that maps joystick button presses to gripper actions.
+
+    This node subscribes to joystick input and calls the appropriate service
+    to open or close the gripper based on button presses.
+
+    Attributes:
+        open_gripper (Client): Client for the open gripper service.
+        close_gripper (Client): Client for the close gripper service.
+        mapping (dict): Mapping of joystick buttons to gripper actions.
+        button_actions (dict): Dictionary mapping button indices to actions.
+        button_states (dict): Dictionary to track the state of each button.
+        busy (bool): Flag to indicate if the node is currently processing a request.
+    """
+
     def __init__(self):
+        """A ROS2 node that maps joystick button presses to gripper actions."""
         super().__init__("joy_to_gripper")
 
         self.declare_parameter("config_pkg", "")
@@ -47,6 +62,11 @@ class JoyToGripper(Node):
         self.busy = False
 
     def handle_input(self, sub_msg: Joy) -> None:
+        """Handle incoming joystick messages and perform actions based on button presses.
+
+        Args:
+            sub_msg (Joy): The incoming joystick message containing button states.
+        """
         for button, action in self.button_actions.items():
             if button >= len(sub_msg.buttons):
                 self.get_logger().warn(
@@ -63,6 +83,11 @@ class JoyToGripper(Node):
     def perform_action_if_not_busy(
         self, action: Literal["open_gripper", "close_gripper"]
     ) -> None:
+        """Perform the specified action if the node is not busy.
+
+        Args:
+            action (Literal["open_gripper", "close_gripper"]): The action to perform.
+        """
         if self.busy:
             return
         self.busy = True
@@ -75,6 +100,11 @@ class JoyToGripper(Node):
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the ROS2 node and spin it.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     executor = MultiThreadedExecutor()
     node = JoyToGripper()

--- a/ros2_ws/src/rcdt_joystick/src_py/joy_to_twist.py
+++ b/ros2_ws/src/rcdt_joystick/src_py/joy_to_twist.py
@@ -15,7 +15,19 @@ ros_logger = logging.get_logger(__name__)
 
 
 class JoyToTwist(Node):
+    """A ROS2 node that converts joystick input to Twist messages.
+
+    This node subscribes to joystick input and publishes Twist messages based on the joystick axes and buttons.
+
+    Attributes:
+        pub (Publisher): Publisher for the Twist or TwistStamped messages.
+        mapping (dict): Mapping of joystick axes to Twist message fields.
+        twist_msg (Twist): The Twist message to be published.
+        twist_stamped_msg (TwistStamped): The TwistStamped message to be published if stamped is True.
+    """
+
     def __init__(self) -> bool:
+        """Initialize the JoyToTwist node."""
         super().__init__("joy_to_twist_node")
         self.declare_parameter("sub_topic", "/joy")
         self.declare_parameter("pub_topic", "")
@@ -59,6 +71,11 @@ class JoyToTwist(Node):
         self.profile = "A"
 
     def handle_input(self, sub_msg: Joy) -> None:
+        """Handle incoming joystick messages and convert them to Twist messages.
+
+        Args:
+            sub_msg (Joy): The incoming joystick message containing axes and buttons.
+        """
         for idx in range(len(sub_msg.axes)):
             joy_value = sub_msg.axes[idx]
             if idx not in self.mapping["axes"]:
@@ -89,6 +106,11 @@ class JoyToTwist(Node):
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the ROS2 node and spin it.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     node = JoyToTwist()
     spin_node(node)

--- a/ros2_ws/src/rcdt_joystick/src_py/joy_to_twist.py
+++ b/ros2_ws/src/rcdt_joystick/src_py/joy_to_twist.py
@@ -26,7 +26,7 @@ class JoyToTwist(Node):
         twist_stamped_msg (TwistStamped): The TwistStamped message to be published if stamped is True.
     """
 
-    def __init__(self) -> bool:
+    def __init__(self) -> None:
         """Initialize the JoyToTwist node."""
         super().__init__("joy_to_twist_node")
         self.declare_parameter("sub_topic", "/joy")
@@ -41,22 +41,22 @@ class JoyToTwist(Node):
         config_pkg = self.get_parameter("config_pkg").get_parameter_value().string_value
         pub_frame = self.get_parameter("pub_frame").get_parameter_value().string_value
 
-        if sub_topic == "":
+        if not sub_topic:
             self.get_logger().warn("No subscriber topic was specified. Exiting.")
             return
 
-        if pub_topic == "":
+        if not pub_topic:
             self.get_logger().warn("No publisher topic was specified. Exiting.")
             return
 
-        if config_pkg == "":
+        if not config_pkg:
             self.get_logger().warn("No package for config file was specified. Exiting.")
             return
 
         config = get_file_path(config_pkg, ["config"], "gamepad_mapping.yaml")
         self.mapping = get_yaml(config)
 
-        if self.mapping == "":
+        if not self.mapping:
             self.get_logger().warn(f"No mapping was found in {config}. Exiting.")
             return
 

--- a/ros2_ws/src/rcdt_joystick/src_py/joy_topic_manager.py
+++ b/ros2_ws/src/rcdt_joystick/src_py/joy_topic_manager.py
@@ -67,7 +67,7 @@ class JoyTopicManager(Node):
         state_pub (Publisher): Publisher for the current state of the active topic.
     """
 
-    def __init__(self) -> bool:
+    def __init__(self) -> None:
         """Initialize the JoyTopicManager node."""
         super().__init__("joy_topic_manager")
         self.declare_parameter("joy_topic", value="/joy")

--- a/ros2_ws/src/rcdt_joystick/src_py/joy_topic_manager.py
+++ b/ros2_ws/src/rcdt_joystick/src_py/joy_topic_manager.py
@@ -24,12 +24,29 @@ latched_qos = QoSProfile(
 
 @dataclass
 class Output:
+    """Data class representing a joystick output configuration.
+
+    Attributes:
+        button (int): The index of the joystick button to monitor.
+        topic (str | None): The topic to publish the Joy message to when the button state changes.
+        moveit (bool): Whether this output is intended for MoveIt! integration.
+        state (int): The current state of the button (pressed or not).
+    """
+
     button: int
     topic: str | None = None
     moveit: bool = False
     state: int = 0
 
     def state_changed(self, state: bool) -> bool:
+        """Check if the state of the button has changed.
+
+        Args:
+            state (bool): The current state of the button (pressed or not).
+
+        Returns:
+            bool: True if the state has changed, False otherwise.
+        """
         if self.state == state:
             return False
         self.state = state
@@ -37,7 +54,21 @@ class Output:
 
 
 class JoyTopicManager(Node):
+    """A ROS2 node that manages joystick topics based on button presses.
+
+    This node subscribes to a joystick input topic and publishes Joy messages to specific topics
+    based on the configuration defined in a YAML file. It allows dynamic topic switching
+    based on joystick button states.
+
+    Attributes:
+        outputs (list[Output]): List of Output configurations loaded from the YAML file.
+        pubs (dict[str, Publisher]): Dictionary mapping topic names to their corresponding publishers.
+        topic (str | None): The currently active topic to which Joy messages are being published.
+        state_pub (Publisher): Publisher for the current state of the active topic.
+    """
+
     def __init__(self) -> bool:
+        """Initialize the JoyTopicManager node."""
         super().__init__("joy_topic_manager")
         self.declare_parameter("joy_topic", value="/joy")
         joy_input = self.get_parameter("joy_topic").get_parameter_value().string_value
@@ -58,10 +89,20 @@ class JoyTopicManager(Node):
         )
 
     def handle_joy_message(self, msg: Joy) -> None:
+        """Handle incoming Joy messages and apply output changes based on button states.
+
+        Args:
+            msg (Joy): The incoming Joy message containing button states.
+        """
         self.apply_output_changes(msg)
         self.pass_joy_message(msg)
 
     def apply_output_changes(self, msg: Joy) -> None:
+        """Apply changes to the output topics based on the current Joy message.
+
+        Args:
+            msg (Joy): The incoming Joy message containing button states.
+        """
         for output in self.outputs:
             if output.button >= len(msg.buttons):
                 self.get_logger().warn(
@@ -73,6 +114,14 @@ class JoyTopicManager(Node):
                 self.topic_changed(output.topic)
 
     def topic_changed(self, topic: str) -> bool:
+        """Change the currently active topic and publish the new state.
+
+        Args:
+            topic (str): The new topic to which Joy messages should be published.
+
+        Returns:
+            bool: True if the topic was changed, False if it remains the same.
+        """
         if self.topic == topic:
             return False
         self.topic = topic
@@ -88,6 +137,11 @@ class JoyTopicManager(Node):
         return True
 
     def pass_joy_message(self, msg: Joy) -> None:
+        """Pass the Joy message to the currently active topic.
+
+        Args:
+            msg (Joy): The Joy message to be published.
+        """
         if self.topic is None:
             return
         pub = self.pubs[self.topic]
@@ -95,6 +149,11 @@ class JoyTopicManager(Node):
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the ROS2 node and spin it.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     node = JoyTopicManager()
     spin_node(node)

--- a/ros2_ws/src/rcdt_mobile_manipulator/launch/core.launch.py
+++ b/ros2_ws/src/rcdt_mobile_manipulator/launch/core.launch.py
@@ -16,6 +16,11 @@ FRANKA_HEIGHT = 0.34
 
 
 def launch_setup(context: LaunchContext) -> None:
+    """Setup the launch description for the mobile manipulator core.
+
+    Args:
+        context (LaunchContext): The launch context.
+    """
     use_sim = use_sim_arg.value(context)
     load_gazebo_ui = load_gazebo_ui_arg.value(context)
     world = str(world_arg.value(context))
@@ -72,6 +77,11 @@ def launch_setup(context: LaunchContext) -> None:
 
 
 def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for the mobile manipulator core.
+
+    Returns:
+        LaunchDescription: The launch description for the mobile manipulator core.
+    """
     return LaunchDescription(
         [
             use_sim_arg.declaration,

--- a/ros2_ws/src/rcdt_mobile_manipulator/launch/mobile_manipulator.launch.py
+++ b/ros2_ws/src/rcdt_mobile_manipulator/launch/mobile_manipulator.launch.py
@@ -15,6 +15,11 @@ use_rviz_arg = LaunchArgument("rviz", True, [True, False])
 
 
 def launch_setup(context: LaunchContext) -> None:
+    """Setup the launch description for the mobile manipulator.
+
+    Args:
+        context (LaunchContext): The launch context.
+    """
     use_sim = use_sim_arg.value(context)
     load_gazebo_ui = load_gazebo_ui_arg.value(context)
     use_rviz = use_rviz_arg.value(context)
@@ -85,6 +90,11 @@ def launch_setup(context: LaunchContext) -> None:
 
 
 def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for the mobile manipulator.
+
+    Returns:
+        LaunchDescription: The launch description for the mobile manipulator.
+    """
     return LaunchDescription(
         [
             use_sim_arg.declaration,

--- a/ros2_ws/src/rcdt_mobile_manipulator/rcdt_mobile_manipulator/test/conftest.py
+++ b/ros2_ws/src/rcdt_mobile_manipulator/rcdt_mobile_manipulator/test/conftest.py
@@ -9,7 +9,11 @@ from rcdt_utilities.register import RegisteredLaunchDescription
 
 @pytest.fixture(scope="module")
 def mobile_manipulator_launch() -> RegisteredLaunchDescription:
-    """Fixture to create launch file for controllers."""
+    """Fixture to create launch file for controllers.
+
+    Returns:
+        RegisteredLaunchDescription: The launch description for the mobile manipulator.
+    """
     return RegisteredLaunchDescription(
         get_file_path(
             "rcdt_mobile_manipulator", ["launch"], "mobile_manipulator.launch.py"

--- a/ros2_ws/src/rcdt_mobile_manipulator/rcdt_mobile_manipulator/test/end_to_end/test_mobile_manipulator_franka.py
+++ b/ros2_ws/src/rcdt_mobile_manipulator/rcdt_mobile_manipulator/test/end_to_end/test_mobile_manipulator_franka.py
@@ -14,6 +14,14 @@ from rcdt_utilities.register import Register, RegisteredLaunchDescription
 def mobile_manipulator(
     mobile_manipulator_launch: RegisteredLaunchDescription,
 ) -> LaunchDescription:
+    """Fixture to launch the mobile manipulator.
+
+    Args:
+        mobile_manipulator_launch (RegisteredLaunchDescription): The launch description for the mobile manipulator.
+
+    Returns:
+        LaunchDescription: The launch description for the mobile manipulator.
+    """
     return Register.connect_context(
         [
             mobile_manipulator_launch,
@@ -23,4 +31,4 @@ def mobile_manipulator(
 
 @pytest.mark.launch(fixture=mobile_manipulator)
 class TestFrankaMMLaunch(FrankaTestSuite()):
-    """Run all the FrankaLaunchTests under mobile_manipulator.launch.py"""
+    """Run all the FrankaLaunchTests under mobile_manipulator.launch.py."""

--- a/ros2_ws/src/rcdt_mobile_manipulator/rcdt_mobile_manipulator/test/end_to_end/test_mobile_manipulator_panther.py
+++ b/ros2_ws/src/rcdt_mobile_manipulator/rcdt_mobile_manipulator/test/end_to_end/test_mobile_manipulator_panther.py
@@ -14,6 +14,14 @@ from rcdt_utilities.register import Register, RegisteredLaunchDescription
 def mobile_manipulator(
     mobile_manipulator_launch: RegisteredLaunchDescription,
 ) -> LaunchDescription:
+    """Fixture to launch the mobile manipulator.
+
+    Args:
+        mobile_manipulator_launch (RegisteredLaunchDescription): The launch description for the mobile manipulator.
+
+    Returns:
+        LaunchDescription: The launch description for the mobile manipulator.
+    """
     return Register.connect_context(
         [
             mobile_manipulator_launch,
@@ -23,4 +31,4 @@ def mobile_manipulator(
 
 @pytest.mark.launch(fixture=mobile_manipulator)
 class TestPantherMMLaunch(PantherTestSuite()):
-    """Run all the PantherFullTests under mobile_manipulator.launch.py"""
+    """Run all the PantherFullTests under mobile_manipulator.launch.py."""

--- a/ros2_ws/src/rcdt_moveit/launch/moveit.launch.py
+++ b/ros2_ws/src/rcdt_moveit/launch/moveit.launch.py
@@ -38,7 +38,7 @@ def launch_setup(context: LaunchContext) -> None:
     file = get_file_path(servo_params_package, ["config"], "servo_params.yaml")
     servo_config = get_yaml(file)
     servo_params = {"moveit_servo": servo_config}
-    if namespace != "":
+    if namespace:
         for param in ["joint_topic", "command_out_topic"]:
             value = servo_params["moveit_servo"][param]
             servo_params["moveit_servo"][param] = "/" + namespace + value

--- a/ros2_ws/src/rcdt_moveit/launch/moveit.launch.py
+++ b/ros2_ws/src/rcdt_moveit/launch/moveit.launch.py
@@ -16,6 +16,11 @@ namespace_arg = LaunchArgument("namespace", "")
 
 
 def launch_setup(context: LaunchContext) -> None:
+    """Setup the launch context for MoveIt with Servo.
+
+    Args:
+        context (LaunchContext): The launch context.
+    """
     robot_name = robot_name_arg.value(context)
     package_name = moveit_package_name_arg.value(context)
     servo_params_package = servo_params_package_arg.value(context)
@@ -72,6 +77,11 @@ def launch_setup(context: LaunchContext) -> None:
 
 
 def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for MoveIt with Servo.
+
+    Returns:
+        LaunchDescription: The launch description containing the actions to be executed.
+    """
     return LaunchDescription(
         [
             robot_name_arg.declaration,

--- a/ros2_ws/src/rcdt_panther/launch/collision_monitor.launch.py
+++ b/ros2_ws/src/rcdt_panther/launch/collision_monitor.launch.py
@@ -10,6 +10,11 @@ use_sim_arg = LaunchArgument("simulation", True, [True, False])
 
 
 def launch_setup(context: LaunchContext) -> None:
+    """Setup the launch description for the collision monitor.
+
+    Args:
+        context (LaunchContext): The launch context.
+    """
     use_sim = use_sim_arg.value(context)
 
     collision_monitor = IncludeLaunchDescription(
@@ -26,6 +31,11 @@ def launch_setup(context: LaunchContext) -> None:
 
 
 def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for the collision monitor.
+
+    Returns:
+        LaunchDescription: The launch description for the collision monitor.
+    """
     return LaunchDescription(
         [
             use_sim_arg.declaration,

--- a/ros2_ws/src/rcdt_panther/launch/controllers.launch.py
+++ b/ros2_ws/src/rcdt_panther/launch/controllers.launch.py
@@ -9,6 +9,11 @@ from rcdt_utilities.register import Register
 
 
 def launch_setup(context: LaunchContext) -> None:
+    """Setup the launch description for the Panther controllers.
+
+    Args:
+        context (LaunchContext): The launch context.
+    """
     namespace = "panther"
 
     joint_state_broadcaster_spawner = Node(
@@ -36,6 +41,11 @@ def launch_setup(context: LaunchContext) -> None:
 
 
 def generate_launch_description() -> None:
+    """Generate the launch description for the Panther controllers.
+
+    Returns:
+        LaunchDescription: The launch description for the Panther controllers.
+    """
     return LaunchDescription(
         [
             OpaqueFunction(function=launch_setup),

--- a/ros2_ws/src/rcdt_panther/launch/core.launch.py
+++ b/ros2_ws/src/rcdt_panther/launch/core.launch.py
@@ -21,6 +21,11 @@ use_velodyne_arg = LaunchArgument("velodyne", False, [True, False])
 
 
 def launch_setup(context: LaunchContext) -> None:
+    """Setup the launch description for the Panther core.
+
+    Args:
+        context (LaunchContext): The launch context.
+    """
     use_sim = use_sim_arg.value(context)
     child = child_arg.value(context)
     load_gazebo_ui = load_gazebo_ui_arg.value(context)
@@ -62,6 +67,11 @@ def launch_setup(context: LaunchContext) -> None:
 
 
 def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for the Panther core.
+
+    Returns:
+        LaunchDescription: The launch description for the Panther core.
+    """
     return LaunchDescription(
         [
             use_sim_arg.declaration,

--- a/ros2_ws/src/rcdt_panther/launch/navigation.launch.py
+++ b/ros2_ws/src/rcdt_panther/launch/navigation.launch.py
@@ -11,6 +11,11 @@ use_sim_arg = LaunchArgument("simulation", True, [True, False])
 
 
 def launch_setup(context: LaunchContext) -> None:
+    """Setup the launch description for the navigation.
+
+    Args:
+        context (LaunchContext): The launch context.
+    """
     use_sim = use_sim_arg.value(context)
 
     navigation = IncludeLaunchDescription(
@@ -29,6 +34,11 @@ def launch_setup(context: LaunchContext) -> None:
 
 
 def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for the navigation.
+
+    Returns:
+        LaunchDescription: The launch description for the navigation.
+    """
     return LaunchDescription(
         [
             use_sim_arg.declaration,

--- a/ros2_ws/src/rcdt_panther/launch/panther.launch.py
+++ b/ros2_ws/src/rcdt_panther/launch/panther.launch.py
@@ -19,6 +19,11 @@ use_nav2_arg = LaunchArgument("nav2", False, [True, False])
 
 
 def launch_setup(context: LaunchContext) -> None:
+    """Setup the launch description for the panther robot.
+
+    Args:
+        context (LaunchContext): The launch context.
+    """
     use_sim = use_sim_arg.value(context)
     load_gazebo_ui = load_gazebo_ui_arg.value(context)
     use_rviz = use_rviz_arg.value(context)
@@ -98,6 +103,11 @@ def launch_setup(context: LaunchContext) -> None:
 
 
 def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for the Panther robot.
+
+    Returns:
+        LaunchDescription: The launch description for the Panther robot.
+    """
     return LaunchDescription(
         [
             use_sim_arg.declaration,

--- a/ros2_ws/src/rcdt_panther/rcdt_panther/test/conftest.py
+++ b/ros2_ws/src/rcdt_panther/rcdt_panther/test/conftest.py
@@ -10,7 +10,11 @@ from rcdt_utilities.register import RegisteredLaunchDescription
 
 @pytest.fixture(scope="module")
 def core_launch() -> RegisteredLaunchDescription:
-    """Fixture to create launch file for the panther core."""
+    """Fixture to create launch file for the panther core.
+
+    Returns:
+        RegisteredLaunchDescription: The launch description for the panther core.
+    """
     return RegisteredLaunchDescription(
         get_file_path("rcdt_panther", ["launch"], "core.launch.py")
     )
@@ -18,7 +22,11 @@ def core_launch() -> RegisteredLaunchDescription:
 
 @pytest.fixture(scope="module")
 def controllers_launch() -> RegisteredLaunchDescription:
-    """Fixture to create launch file for the panther controllers."""
+    """Fixture to create launch file for the panther controllers.
+
+    Returns:
+        RegisteredLaunchDescription: The launch description for the panther controllers.
+    """
     return RegisteredLaunchDescription(
         get_file_path("rcdt_panther", ["launch"], "controllers.launch.py")
     )
@@ -26,7 +34,11 @@ def controllers_launch() -> RegisteredLaunchDescription:
 
 @pytest.fixture(scope="module")
 def navigation_launch() -> RegisteredLaunchDescription:
-    """Fixture to create launch file for the panther navigation."""
+    """Fixture to create launch file for the panther navigation.
+
+    Returns:
+        RegisteredLaunchDescription: The launch description for the panther navigation.
+    """
     return RegisteredLaunchDescription(
         get_file_path("rcdt_panther", ["launch"], "navigation.launch.py")
     )

--- a/ros2_ws/src/rcdt_panther/rcdt_panther/test/end_to_end/base_panther.py
+++ b/ros2_ws/src/rcdt_panther/rcdt_panther/test/end_to_end/base_panther.py
@@ -15,15 +15,41 @@ from sensor_msgs.msg import JointState
 
 
 def get_tests() -> dict:
-    """Test class for the Panther."""
+    """Test class for the Panther.
+
+    This class contains all the tests that are run in the Panther test suite.
+    It dynamically creates test methods based on the defined functions.
+
+    Returns:
+        dict: A dictionary of test methods.
+    """
 
     def test_wait_for_register(_self: object, timeout: int) -> None:
+        """Wait for the Panther to register.
+
+        Args:
+            _self (object): The test class instance.
+            timeout (int): The timeout in seconds to wait before failing the test.
+        """
         wait_for_register(timeout=timeout)
 
     def test_joint_states_published(_self: object, timeout: int) -> None:
+        """Test that the joint states are published.
+
+        Args:
+            _self (object): The test class instance.
+            timeout (int): The timeout in seconds to wait before failing the test.
+        """
         assert_for_message(JointState, "/panther/joint_states", timeout=timeout)
 
     def test_e_stop_request(_self: object, test_node: Node, timeout: int) -> None:
+        """Test that the E-Stop request service can be called.
+
+        Args:
+            _self (object): The test class instance.
+            test_node (Node): The ROS 2 node to use for the test.
+            timeout (int): The timeout in seconds to wait before failing the test.
+        """
         assert (
             call_trigger_service(
                 node=test_node,
@@ -36,6 +62,13 @@ def get_tests() -> dict:
     def test_switch_joy_to_panther_topic(
         _self: object, test_node: Node, timeout: int
     ) -> None:
+        """Test that the joy topic switches to the Panther topic.
+
+        Args:
+            _self (object): The test class instance.
+            test_node (Node): The ROS 2 node to use for the test.
+            timeout (int): The timeout in seconds to wait before failing the test.
+        """
         assert_joy_topic_switch(
             node=test_node,
             expected_topic="/panther/joy",
@@ -46,6 +79,14 @@ def get_tests() -> dict:
     def test_move_panther_with_joy(
         _self: object, test_node: Node, timeout: int
     ) -> None:
+        """Test that the Panther can be moved with the joy topic.
+
+        Args:
+            _self (object): The test class instance.
+            test_node (Node): The ROS 2 node to use for the test.
+            timeout (int): The timeout in seconds to wait before failing the test.
+        """
+
         def compare_fn(p1: Pose, p2: Pose) -> float:
             return p2.position.x - p1.position.x
 
@@ -63,6 +104,14 @@ def get_tests() -> dict:
     def test_rotate_panther_with_joy(
         _self: object, test_node: Node, timeout: int
     ) -> None:
+        """Test that the Panther can be rotated with the joy topic.
+
+        Args:
+            _self (object): The test class instance.
+            test_node (Node): The ROS 2 node to use for the test.
+            timeout (int): The timeout in seconds to wait before failing the test.
+        """
+
         def compare_fn(p1: Pose, p2: Pose) -> float:
             return p2.orientation.w - p1.orientation.w
 
@@ -88,5 +137,9 @@ def get_tests() -> dict:
 
 
 def PantherTestSuite() -> object:  # noqa: N802
-    """Dynamically create a test class with the test methods."""
+    """Dynamically create a test class with the test methods.
+
+    Returns:
+        object: A dynamically created test class with the test methods.
+    """
     return type("PantherFullTests", (), get_tests())

--- a/ros2_ws/src/rcdt_panther/rcdt_panther/test/end_to_end/test_panther.py
+++ b/ros2_ws/src/rcdt_panther/rcdt_panther/test/end_to_end/test_panther.py
@@ -13,6 +13,11 @@ from rcdt_utilities.register import Register, RegisteredLaunchDescription
 
 @launch_pytest.fixture(scope="module")
 def panther_launch() -> LaunchDescription:
+    """Fixture to create launch file for panther robot.
+
+    Returns:
+        RegisteredLaunchDescription: The launch description for the panther robot.
+    """
     panther = RegisteredLaunchDescription(
         get_file_path("rcdt_panther", ["launch"], "panther.launch.py"),
         launch_arguments={
@@ -27,4 +32,4 @@ def panther_launch() -> LaunchDescription:
 
 @pytest.mark.launch(fixture=panther_launch)
 class TestPantherFullSuite(PantherTestSuite()):
-    """Re-run all tests from PantherFullTests using panther.launch.py"""
+    """Re-run all tests from PantherFullTests using panther.launch.py."""

--- a/ros2_ws/src/rcdt_panther/rcdt_panther/test/integration/test_panther_core.py
+++ b/ros2_ws/src/rcdt_panther/rcdt_panther/test/integration/test_panther_core.py
@@ -25,21 +25,46 @@ def panther_core_launch(
     core_launch: RegisteredLaunchDescription,
     controllers_launch: RegisteredLaunchDescription,
 ) -> LaunchDescription:
+    """Fixture to create launch file for panther core and controllers.
+
+    Args:
+        core_launch (RegisteredLaunchDescription): The launch description for the panther core.
+        controllers_launch (RegisteredLaunchDescription): The launch description for the panther controllers.
+
+    Returns:
+        LaunchDescription: The launch description for the panther core and controllers.
+    """
     return Register.connect_context([core_launch, controllers_launch])
 
 
 @pytest.mark.launch(fixture=panther_core_launch)
 def test_wait_for_register(timeout: int) -> None:
+    """Test that the panther core is registered in the RCDT.
+
+    Args:
+        timeout (int): The timeout in seconds to wait for the panther core to register.
+    """
     wait_for_register(timeout=timeout)
 
 
 @pytest.mark.launch(fixture=panther_core_launch)
 def test_joint_states_published(timeout: int) -> None:
+    """Test that the joint states are published.
+
+    Args:
+        timeout (int): The timeout in seconds to wait for the joint states to be published.
+    """
     assert_for_message(JointState, "/panther/joint_states", timeout=timeout)
 
 
 @pytest.mark.launch(fixture=panther_core_launch)
 def test_e_stop_request(test_node: Node, timeout: int) -> None:
+    """Test that the E-Stop request service can be called.
+
+    Args:
+        test_node (Node): The ROS 2 node to use for the test.
+        timeout (int): The timeout in seconds to wait for the service to be called.
+    """
     assert (
         call_trigger_service(
             node=test_node,
@@ -52,8 +77,12 @@ def test_e_stop_request(test_node: Node, timeout: int) -> None:
 
 @pytest.mark.launch(fixture=panther_core_launch)
 def test_driving(test_node: Node, timeout: int) -> None:
-    """Test that the controllers work and the wheels have turned."""
+    """Test that the controllers work and the wheels have turned.
 
+    Args:
+        test_node (Node): The ROS 2 node to use for the test.
+        timeout (int): The timeout in seconds to wait for the wheels to turn.
+    """
     joint_value_before_driving = get_joint_position(
         "panther", "fl_wheel_joint", timeout=timeout
     )

--- a/ros2_ws/src/rcdt_sensors/src_py/combine_camera_topics.py
+++ b/ros2_ws/src/rcdt_sensors/src_py/combine_camera_topics.py
@@ -26,7 +26,7 @@ class CombineCameraTopics(Node):
         pub (Publisher): Publisher for the RGBD message.
     """
 
-    def __init__(self) -> bool:
+    def __init__(self) -> None:
         """Initialize the CombineCameraTopics node."""
         super().__init__("combine_camera_topics")
         self.declare_parameter("rgb", "/camera/camera/color/image_raw")

--- a/ros2_ws/src/rcdt_sensors/src_py/combine_camera_topics.py
+++ b/ros2_ws/src/rcdt_sensors/src_py/combine_camera_topics.py
@@ -15,7 +15,19 @@ ros_logger = logging.get_logger(__name__)
 
 
 class CombineCameraTopics(Node):
+    """A ROS2 node that combines RGB and depth camera topics into a single RGBD message.
+
+    This node subscribes to the RGB and depth image topics, as well as their corresponding
+    camera info topics. It publishes a combined RGBD message that contains both the RGB image
+    and the depth image, along with their camera information.
+
+    Attributes:
+        rgbd (RGBD): The combined RGBD message containing RGB and depth images.
+        pub (Publisher): Publisher for the RGBD message.
+    """
+
     def __init__(self) -> bool:
+        """Initialize the CombineCameraTopics node."""
         super().__init__("combine_camera_topics")
         self.declare_parameter("rgb", "/camera/camera/color/image_raw")
         self.declare_parameter("depth", "/camera/camera/depth/image_rect_raw")
@@ -39,22 +51,32 @@ class CombineCameraTopics(Node):
         self.create_timer(1 / 30, self.publish_rgbd)
 
     def publish_rgbd(self) -> None:
+        """Publish the combined RGBD message."""
         self.pub.publish(self.rgbd)
 
     def update_rgb(self, msg: Image) -> None:
+        """Update the RGB image in the RGBD message."""
         self.rgbd.rgb = msg
 
     def update_depth(self, msg: Image) -> None:
+        """Update the depth image in the RGBD message."""
         self.rgbd.depth = msg
 
     def update_rgb_info(self, msg: CameraInfo) -> None:
+        """Update the RGB camera info in the RGBD message."""
         self.rgbd.rgb_camera_info = msg
 
     def update_depth_info(self, msg: CameraInfo) -> None:
+        """Update the depth camera info in the RGBD message."""
         self.rgbd.depth_camera_info = msg
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the ROS2 node and spin it.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     node = CombineCameraTopics()
     spin_node(node)

--- a/ros2_ws/src/rcdt_sensors/src_py/convert_32FC1_to_16UC1.py
+++ b/ros2_ws/src/rcdt_sensors/src_py/convert_32FC1_to_16UC1.py
@@ -25,7 +25,7 @@ class Convert32FC1to16UC1(Node):
         publisher (Publisher): Publisher for the converted 16UC1 depth image.
     """
 
-    def __init__(self) -> bool:
+    def __init__(self) -> None:
         """Initialize the Convert32FC1to16UC1 node."""
         super().__init__("convert_32FC1_to_16UC1_node")
 

--- a/ros2_ws/src/rcdt_sensors/src_py/convert_32FC1_to_16UC1.py
+++ b/ros2_ws/src/rcdt_sensors/src_py/convert_32FC1_to_16UC1.py
@@ -16,7 +16,17 @@ ros_logger = logging.get_logger(__name__)
 
 
 class Convert32FC1to16UC1(Node):
+    """A ROS2 node that converts 32FC1 depth images to 16UC1 format.
+
+    This node subscribes to a 32FC1 depth image topic, converts the image data to
+    16UC1 format (millimeters), and publishes the converted image to a new topic.
+
+    Attributes:
+        publisher (Publisher): Publisher for the converted 16UC1 depth image.
+    """
+
     def __init__(self) -> bool:
+        """Initialize the Convert32FC1to16UC1 node."""
         super().__init__("convert_32FC1_to_16UC1_node")
 
         self.create_subscription(
@@ -27,6 +37,11 @@ class Convert32FC1to16UC1(Node):
         )
 
     def callback(self, msg: Image) -> None:
+        """Callback function to process incoming 32FC1 depth images.
+
+        Args:
+            msg (Image): The incoming 32FC1 depth image message.
+        """
         cv2_image = ros_image_to_cv2_image(msg)
         cv2_image *= 1000  # m to mm
         cv2_image = cv2_image.astype(np.uint16)
@@ -36,6 +51,11 @@ class Convert32FC1to16UC1(Node):
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the ROS2 node and spin it.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     node = Convert32FC1to16UC1()
     spin_node(node)

--- a/ros2_ws/src/rcdt_utilities/launch/rviz.launch.py
+++ b/ros2_ws/src/rcdt_utilities/launch/rviz.launch.py
@@ -16,6 +16,11 @@ moveit_package_name_arg = LaunchArgument("moveit_package_name", "")
 
 
 def launch_setup(context: LaunchContext) -> None:
+    """Setup the launch description for RViz.
+
+    Args:
+        context (LaunchContext): The launch context.
+    """
     rviz_frame = rviz_frame_arg.value(context)
     rviz_display_config = rviz_display_config_arg.value(context)
     robot_name = robot_name_arg.value(context)
@@ -49,6 +54,11 @@ def launch_setup(context: LaunchContext) -> None:
 
 
 def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for RViz.
+
+    Returns:
+        LaunchDescription: The launch description for RViz.
+    """
     return LaunchDescription(
         [
             rviz_frame_arg.declaration,

--- a/ros2_ws/src/rcdt_utilities/launch/rviz.launch.py
+++ b/ros2_ws/src/rcdt_utilities/launch/rviz.launch.py
@@ -27,13 +27,13 @@ def launch_setup(context: LaunchContext) -> None:
     package_name = moveit_package_name_arg.value(context)
 
     arguments = []
-    if rviz_frame != "":
+    if rviz_frame:
         arguments.extend(["-f", rviz_frame])
     display_config = get_file_path("rcdt_utilities", ["rviz"], rviz_display_config)
     arguments.extend(["--display-config", display_config])
 
     parameters = []
-    if package_name != "":
+    if package_name:
         moveit_config = MoveItConfigsBuilder(robot_name, package_name=package_name)
         moveit_config = moveit_config.to_moveit_configs()
         parameters.append(moveit_config.robot_description)

--- a/ros2_ws/src/rcdt_utilities/launch/utils.launch.py
+++ b/ros2_ws/src/rcdt_utilities/launch/utils.launch.py
@@ -9,8 +9,11 @@ from rcdt_utilities.register import Register
 
 
 def launch_setup(context: LaunchContext) -> None:
-    """Launches the utilities launch file."""
+    """Launches the utilities launch file.
 
+    Args:
+        context (LaunchContext): The launch context.
+    """
     manipulate_pose = Node(package="rcdt_utilities", executable="manipulate_pose.py")
 
     return [
@@ -19,5 +22,9 @@ def launch_setup(context: LaunchContext) -> None:
 
 
 def generate_launch_description() -> LaunchDescription:
-    """Launches the utilities launch file."""
+    """Launches the utilities launch file.
+
+    Returns:
+        LaunchDescription: The launch description for the utilities launch file.
+    """
     return LaunchDescription([OpaqueFunction(function=launch_setup)])

--- a/ros2_ws/src/rcdt_utilities/rcdt_utilities/cv_utils.py
+++ b/ros2_ws/src/rcdt_utilities/rcdt_utilities/cv_utils.py
@@ -13,17 +13,40 @@ cv_bridge = CvBridge()
 def ros_image_to_cv2_image(
     image_message: Image, desired_encoding: str = "passthrough"
 ) -> ndarray:
-    """Convert ROS image message to cv2 image."""
+    """Convert ROS image message to cv2 image.
+
+    Args:
+        image_message (Image): The ROS image message to convert.
+        desired_encoding (str): The desired encoding for the output image. Defaults to "passthrough".
+
+    Returns:
+        ndarray: The converted cv2 image.
+    """
     return cv_bridge.imgmsg_to_cv2(image_message, desired_encoding=desired_encoding)
 
 
 def cv2_image_to_ros_image(image: ndarray, encoding: str = "passthrough") -> Image:
-    """Convert cv2 image message to ROS image."""
+    """Convert cv2 image message to ROS image.
+
+    Args:
+        image (ndarray): The cv2 image to convert.
+        encoding (str): The desired encoding for the output image. Defaults to "passthrough".
+
+    Returns:
+        Image: The converted ROS image message.
+    """
     return cv_bridge.cv2_to_imgmsg(image, encoding=encoding)
 
 
 def camera_info_to_intrinsics(camera_info: CameraInfo) -> rs2.intrinsics:
-    """Calculate camera intrinsics for translating image to world coordinates."""
+    """Calculate camera intrinsics for translating image to world coordinates.
+
+    Args:
+        camera_info (CameraInfo): The camera info message containing the camera parameters.
+
+    Returns:
+        rs2.intrinsics: The calculated camera intrinsics.
+    """
     intrinsics = rs2.intrinsics()
 
     intrinsics.width = camera_info.width

--- a/ros2_ws/src/rcdt_utilities/rcdt_utilities/geometry.py
+++ b/ros2_ws/src/rcdt_utilities/rcdt_utilities/geometry.py
@@ -15,24 +15,52 @@ from tf_transformations import quaternion_from_euler
 
 @dataclass
 class Point2D:
+    """A 2D point in space.
+
+    Attributes:
+        x (float): The x-coordinate of the point.
+        y (float): The y-coordinate of the point.
+    """
+
     x: float
     y: float
 
     @property
     def as_tuple(self) -> tuple:
-        """Return point as tuple."""
+        """Return point as tuple.
+
+        Returns:
+            tuple: A tuple containing the x and y coordinates of the point.
+        """
         return self.x, self.y
 
     @property
     def as_int_tuple(self) -> tuple:
+        """Return point as tuple of integers.
+
+        Returns:
+            tuple: A tuple containing the x and y coordinates of the point as integers.
+        """
         return int(self.x), int(self.y)
 
     @property
     def as_array(self) -> np.ndarray:
+        """Return point as numpy array.
+
+        Returns:
+            np.ndarray: A numpy array containing the x and y coordinates of the point.
+        """
         return np.array([self.x, self.y])
 
     def surrounding_points(self, grid_size: np.ndarray = 5) -> "Point2DList":
-        """Return a dense list of 2D points around self with distance of up to grid_size."""
+        """Return a dense list of 2D points around self with distance of up to grid_size.
+
+        Args:
+            grid_size (np.ndarray, optional): The size of the grid around the point. Defaults to 5.
+
+        Returns:
+            Point2DList: A list of surrounding points.
+        """
         surrounding_points = []
         for x_pos in range(self.x - grid_size, self.x + grid_size):
             for y_pos in range(self.y - grid_size, self.y + grid_size):
@@ -42,17 +70,39 @@ class Point2D:
 
 @dataclass
 class Point3D:
+    """A 3D point in space.
+
+    Attributes:
+        x (float): The x-coordinate of the point.
+        y (float): The y-coordinate of the point.
+        z (float): The z-coordinate of the point.
+    """
+
     x: float
     y: float
     z: float
 
     @property
     def as_ros_point(self) -> ros_Point:
+        """Return point as ROS Point message.
+
+        Returns:
+            ros_Point: A ROS Point message containing the x, y, and z coordinates of the point.
+        """
         return ros_Point(x=self.x, y=self.y, z=self.z)
 
 
 @dataclass
 class Quaternion:
+    """A quaternion representing orientation in 3D space.
+
+    Attributes:
+        x (float): The x component of the quaternion.
+        y (float): The y component of the quaternion.
+        z (float): The z component of the quaternion.
+        w (float): The w component of the quaternion.
+    """
+
     x: float
     y: float
     z: float
@@ -60,30 +110,72 @@ class Quaternion:
 
     @property
     def as_tuple(self) -> tuple:
+        """Return quaternion as tuple.
+
+        Returns:
+            tuple: A tuple containing the x, y, z, and w components of the quaternion.
+        """
         return self.x, self.y, self.z, self.w
 
     @staticmethod
     def from_eulerangles(x: float, y: float, z: float) -> "Quaternion":
+        """Create a quaternion from Euler angles (in radians).
+
+        Args:
+            x (float): The roll angle in radians.
+            y (float): The pitch angle in radians.
+            z (float): The yaw angle in radians.
+
+        Returns:
+            Quaternion: A quaternion representing the orientation defined by the Euler angles.
+        """
         return Quaternion(*quaternion_from_euler(x, y, z))
 
     @staticmethod
     def from_eulerangles_deg(x: float, y: float, z: float) -> "Quaternion":
+        """Create a quaternion from Euler angles (in degrees).
+
+        Args:
+            x (float): The roll angle in degrees.
+            y (float): The pitch angle in degrees.
+            z (float): The yaw angle in degrees.
+
+        Returns:
+            Quaternion: A quaternion representing the orientation defined by the Euler angles.
+        """
         return Quaternion(
             *quaternion_from_euler(np.deg2rad(x), np.deg2rad(y), np.deg2rad(z))
         )
 
     @property
     def as_ros_quaternion(self) -> ros_Quaternion:
+        """Return quaternion as ROS Quaternion message.
+
+        Returns:
+            ros_Quaternion: A ROS Quaternion message containing the x, y, z, and w components of the quaternion.
+        """
         return ros_Quaternion(x=self.x, y=self.y, z=self.z, w=self.w)
 
 
 @dataclass
 class Pose:
+    """A pose in 3D space defined by a position and orientation.
+
+    Attributes:
+        position (Point3D): The position of the pose in 3D space.
+        orientation (Quaternion): The orientation of the pose in 3D space.
+    """
+
     position: Point3D
     orientation: Quaternion
 
     @property
     def as_ros_pose(self) -> ros_Pose:
+        """Return pose as ROS Pose message.
+
+        Returns:
+            ros_Pose: A ROS Pose message containing the position and orientation of the pose.
+        """
         return ros_Pose(
             position=self.position.as_ros_point,
             orientation=self.orientation.as_ros_quaternion,
@@ -92,32 +184,73 @@ class Pose:
 
 @dataclass
 class Point2DList:
+    """A list of 2D points.
+
+    Attributes:
+        points (list[Point2D]): A list of Point2D objects.
+    """
+
     points: list[Point2D]
 
     @property
     def mean(self) -> Point2D:
+        """Calculate the mean of all points in the list.
+
+        Returns:
+            Point2D: A Point2D object representing the mean of all points in the list.
+        """
         return Point2D(*np.mean([point.as_array for point in self.points], axis=0))
 
 
 @dataclass
 class Line:
+    """A line segment defined by two 2D points.
+
+    Attributes:
+        p1 (Point2D): The first point of the line segment.
+        p2 (Point2D): The second point of the line segment.
+    """
+
     p1: Point2D
     p2: Point2D
 
     @property
     def length(self) -> float:
+        """Calculate the length of the line segment.
+
+        Returns:
+            float: The length of the line segment.
+        """
         return np.linalg.norm(self.p1.as_array - self.p2.as_array)
 
     @property
     def flipped(self) -> "Line":
+        """Return a new Line with the points flipped.
+
+        Returns:
+            Line: A new Line object with the points p1 and p2 swapped.
+        """
         return Line(self.p2, self.p1)
 
     def points_along(self, n: int) -> list[Point2D]:
+        """Calculate n points along the line segment, excluding the endpoints.
+
+        Args:
+            n (int): The number of points to calculate along the line segment.
+
+        Returns:
+            list[Point2D]: A list of Point2D objects representing the points along the line segment.
+        """
         points = np.linspace(self.p1.as_array, self.p2.as_array, n + 2, dtype=int)
         points = points[1:-1]  # remove edges
         return [Point2D(*point) for point in points]
 
     def angle(self) -> float:
+        """Calculate the angle of the line segment in radians.
+
+        Returns:
+            float: The angle of the line segment in radians, measured from the positive x-axis.
+        """
         dx = self.p2.x - self.p1.x
         dy = self.p2.y - self.p1.y
         return atan2(dy, dx)
@@ -125,10 +258,25 @@ class Line:
 
 @dataclass
 class SidePair:
+    """A pair of line segments representing the long sides of a bounding box.
+
+    Attributes:
+        side1 (Line): The first line segment of the pair.
+        side2 (Line): The second line segment of the pair.
+    """
+
     side1: Line
     side2: Line
 
     def point_pairs(self, n: int = 5) -> list[Point2DList]:
+        """Calculate n pairs of points along the long sides of the bounding box.
+
+        Args:
+            n (int): The number of pairs of points to calculate along the long sides.
+
+        Returns:
+            list[Point2DList]: A list of Point2DList objects, each containing a pair of points from the two sides.
+        """
         points1 = self.side1.points_along(n)
         points2 = self.side2.points_along(n)
         return [Point2DList([points1[i], points2[i]]) for i in range(n)]
@@ -136,6 +284,16 @@ class SidePair:
 
 @dataclass
 class BoundingBox:
+    """A bounding box defined by its center, width, height, and rotation angle.
+
+    Attributes:
+        x (float): The x-coordinate of the center of the bounding box.
+        y (float): The y-coordinate of the center of the bounding box.
+        w (float): The width of the bounding box.
+        h (float): The height of the bounding box.
+        angle_deg (float): The rotation angle of the bounding box in degrees.
+    """
+
     x: float
     y: float
     w: float
@@ -144,19 +302,41 @@ class BoundingBox:
 
     @property
     def ordered_values(self) -> tuple[float]:
+        """Return the bounding box values in a specific order.
+
+        Returns:
+            tuple[float]: A tuple containing the x, y, w, h, and angle_deg values of the bounding box.
+        """
         return (self.x, self.y, self.w, self.h, self.angle_deg)
 
     @property
     def center(self) -> Point2D:
+        """Return the center point of the bounding box.
+
+        Returns:
+            Point2D: A Point2D object representing the center of the bounding box.
+        """
         return Point2D(self.x, self.y)
 
     @property
     def corners(self) -> list[Point2D]:
+        """Calculate the corners of the bounding box.
+
+        Returns:
+            list[Point2D]: A list of Point2D objects representing the corners of the bounding box.
+        """
         x, y, w, h, angle_deg = self.ordered_values
         return [Point2D(*point) for point in cv2.boxPoints(((x, y), (w, h), angle_deg))]
 
     @property
     def long_sides_offset(self) -> SidePair:
+        """Calculate the long sides of the bounding box with an offset.
+
+        This method adjusts the width or height of the bounding box by a factor to ensure the long sides are longer than the short sides.
+
+        Returns:
+            SidePair: A SidePair object containing the two long sides of the bounding box.
+        """
         offset_factor: float = 1.6
         if self.h > self.w:
             self.w *= offset_factor

--- a/ros2_ws/src/rcdt_utilities/rcdt_utilities/launch_utils.py
+++ b/ros2_ws/src/rcdt_utilities/rcdt_utilities/launch_utils.py
@@ -119,7 +119,7 @@ def get_yaml(file_path: str) -> yaml.YAMLObject:
         yaml.YAMLObject: The contents of the YAML file, or None if the file cannot be read.
     """
     try:
-        with open(file_path, "r") as file:
+        with open(file_path, "r", encoding="utf-8") as file:
             return yaml.safe_load(file)
     except EnvironmentError:
         return None
@@ -146,10 +146,6 @@ def spin_node(node: Node) -> None:
 
     Args:
         node (Node): The ROS 2 node to spin.
-
-    Raises:
-        KeyboardInterrupt: If the spinning is interrupted by the user.
-        Exception: If any other exception occurs during spinning.
     """
     try:
         rclpy.spin(node)
@@ -164,10 +160,6 @@ def spin_executor(executor: Executor) -> None:
 
     Args:
         executor (Executor): The ROS 2 executor to spin.
-
-    Raises:
-        KeyboardInterrupt: If the spinning is interrupted by the user.
-        Exception: If any other exception occurs during spinning.
     """
     try:
         executor.spin()

--- a/ros2_ws/src/rcdt_utilities/rcdt_utilities/launch_utils.py
+++ b/ros2_ws/src/rcdt_utilities/rcdt_utilities/launch_utils.py
@@ -22,12 +22,30 @@ WAIT = 3
 
 
 class LaunchArgument:
+    """A class to handle launch arguments in ROS 2 launch files.
+
+    This class allows you to declare a launch argument with a default value and optional choices.
+    It also provides a method to retrieve the value of the argument in a launch context.
+
+    Attributes:
+        name (str): The name of the launch argument.
+        default_value (str | bool | int | float): The default value of the launch argument.
+        choices (List, optional): A list of valid choices for the launch argument. Defaults to None.
+    """
+
     def __init__(
         self,
         name: str,
         default_value: str | bool | int | float,
         choices: List = None,
     ) -> None:
+        """Initializes a LaunchArgument instance.
+
+        Args:
+            name (str): The name of the launch argument.
+            default_value (str | bool | int | float): The default value of the launch argument.
+            choices (List, optional): A list of valid choices for the launch argument. Defaults to None.
+        """
         self.configuration = LaunchConfiguration(name)
         if choices is not None:
             choices = [str(choice) for choice in choices]
@@ -36,6 +54,14 @@ class LaunchArgument:
         )
 
     def value(self, context: LaunchContext) -> str | bool | int | float:
+        """Retrieves the value of the launch argument in the given context.
+
+        Args:
+            context (LaunchContext): The launch context in which to evaluate the argument.
+
+        Returns:
+            str | bool | int | float: The evaluated value of the launch argument.
+        """
         string_value = self.configuration.perform(context)
         try:
             return ast.literal_eval(string_value)
@@ -44,20 +70,54 @@ class LaunchArgument:
 
 
 def get_package_path(package: str) -> str:
+    """Retrieve the share directory path of a ROS 2 package.
+
+    Args:
+        package (str): The name of the ROS 2 package.
+
+    Returns:
+        str: The path to the package's share directory.
+    """
     return get_package_share_directory(package)
 
 
 def get_lib_path(package: str) -> str:
+    """Retrieve the library directory path of a ROS 2 package.
+
+    Args:
+        package (str): The name of the ROS 2 package.
+
+    Returns:
+        str: The path to the package's library directory.
+    """
     package_prefix = get_package_prefix(package) + ""
     return os.path.join(package_prefix, "lib", package)
 
 
 def get_file_path(package: str, folders: List[str], file: str) -> str:
+    """Construct a file path within a ROS 2 package.
+
+    Args:
+        package (str): The name of the ROS 2 package.
+        folders (List[str]): A list of folder names leading to the file.
+        file (str): The name of the file.
+
+    Returns:
+        str: The full path to the specified file within the package.
+    """
     package_path = get_package_path(package)
     return os.path.join(package_path, *folders, file)
 
 
 def get_yaml(file_path: str) -> yaml.YAMLObject:
+    """Load a YAML file and return its contents.
+
+    Args:
+        file_path (str): The path to the YAML file.
+
+    Returns:
+        yaml.YAMLObject: The contents of the YAML file, or None if the file cannot be read.
+    """
     try:
         with open(file_path, "r") as file:
             return yaml.safe_load(file)
@@ -66,6 +126,15 @@ def get_yaml(file_path: str) -> yaml.YAMLObject:
 
 
 def get_robot_description(xacro_path: str, xacro_arguments: dict = None) -> str:
+    """Process a Xacro file to generate the robot description.
+
+    Args:
+        xacro_path (str): The path to the Xacro file.
+        xacro_arguments (dict, optional): A dictionary of arguments to pass to the Xacro processor. Defaults to None.
+
+    Returns:
+        str: The robot description in XML format.
+    """
     if xacro_arguments is None:
         xacro_arguments = {}
     robot_description_config = xacro.process_file(xacro_path, mappings=xacro_arguments)
@@ -73,6 +142,15 @@ def get_robot_description(xacro_path: str, xacro_arguments: dict = None) -> str:
 
 
 def spin_node(node: Node) -> None:
+    """Spin a ROS 2 node to process callbacks and keep it alive.
+
+    Args:
+        node (Node): The ROS 2 node to spin.
+
+    Raises:
+        KeyboardInterrupt: If the spinning is interrupted by the user.
+        Exception: If any other exception occurs during spinning.
+    """
     try:
         rclpy.spin(node)
     except KeyboardInterrupt:
@@ -82,6 +160,15 @@ def spin_node(node: Node) -> None:
 
 
 def spin_executor(executor: Executor) -> None:
+    """Spin a ROS 2 executor to process callbacks from multiple nodes.
+
+    Args:
+        executor (Executor): The ROS 2 executor to spin.
+
+    Raises:
+        KeyboardInterrupt: If the spinning is interrupted by the user.
+        Exception: If any other exception occurs during spinning.
+    """
     try:
         executor.spin()
     except KeyboardInterrupt:
@@ -91,6 +178,13 @@ def spin_executor(executor: Executor) -> None:
 
 
 def assert_for_message(message_type: type, topic: str, timeout: int) -> bool:
+    """Assert that a message of a specific type is received on a given topic within a timeout period.
+
+    Args:
+        message_type (type): The type of the message to wait for.
+        topic (str): The topic to listen to.
+        timeout (int): The maximum time in seconds to wait for the message.
+    """
     wait_for_topics = WaitForTopics([(topic, message_type)], timeout)
     received = wait_for_topics.wait()
     wait_for_topics.shutdown()

--- a/ros2_ws/src/rcdt_utilities/rcdt_utilities/launch_utils.py
+++ b/ros2_ws/src/rcdt_utilities/rcdt_utilities/launch_utils.py
@@ -73,6 +73,9 @@ class LaunchArgument:
         Args:
             context (LaunchContext): The launch context in which to evaluate the argument.
 
+        Raises:
+            TypeError: If the string value cannot be interpreted as a boolean.
+
         Returns:
             bool: The boolean value of the launch argument.
         """

--- a/ros2_ws/src/rcdt_utilities/rcdt_utilities/register.py
+++ b/ros2_ws/src/rcdt_utilities/rcdt_utilities/register.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Union
+from typing import Union
 
 from launch import LaunchContext, LaunchDescription
 from launch.actions import (
@@ -89,11 +89,11 @@ class Register:
         Register.started = 0
 
     @staticmethod
-    def next(*_: Any) -> LaunchDescription:
+    def next(*_: RegisteredLaunchDescription) -> LaunchDescription:
         """Returns the next action to start based on the order of registration.
 
         Args:
-            *_ (Any): Variable length argument list, not used in this method.
+            *_ (RegisteredLaunchDescription): Ignored.  Comes from the OpaqueFunction.
 
         Returns:
             LaunchDescription: A launch description containing the next action to start, or an empty launch description if all actions have been started.

--- a/ros2_ws/src/rcdt_utilities/rcdt_utilities/register.py
+++ b/ros2_ws/src/rcdt_utilities/rcdt_utilities/register.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Union
+from typing import Any, Union
 
 from launch import LaunchContext, LaunchDescription
 from launch.actions import (
@@ -89,11 +89,11 @@ class Register:
         Register.started = 0
 
     @staticmethod
-    def next(*_: RegisteredLaunchDescription) -> LaunchDescription:
+    def next(*_: Any) -> LaunchDescription:
         """Returns the next action to start based on the order of registration.
 
         Args:
-            *_ (RegisteredLaunchDescription): Ignored.  Comes from the OpaqueFunction.
+            *_ (Any): Ignored. Additional arguments from `OnProcessStart` or `OnProcessExit`.
 
         Returns:
             LaunchDescription: A launch description containing the next action to start, or an empty launch description if all actions have been started.

--- a/ros2_ws/src/rcdt_utilities/rcdt_utilities/register.py
+++ b/ros2_ws/src/rcdt_utilities/rcdt_utilities/register.py
@@ -149,9 +149,6 @@ class Register:
 
         Returns:
             LaunchDescription: A LaunchDescription containing an OpaqueFunction that sets up the launch items.
-
-        Raises:
-            TypeError: If any of the items in the groups list is not an instance of RegisteredLaunchDescription.
         """
 
         def launch_setup(

--- a/ros2_ws/src/rcdt_utilities/rcdt_utilities/register.py
+++ b/ros2_ws/src/rcdt_utilities/rcdt_utilities/register.py
@@ -22,9 +22,22 @@ CONF_NAME = "registered_group"
 
 
 class RegisteredLaunchDescription(IncludeLaunchDescription):
-    """Extends on the default IncludeLaunchDescription, to automatically register an unique group_id."""
+    """Extends on the default IncludeLaunchDescription, to automatically register an unique group_id.
+
+    Atributes:
+        launch_description_source (str): The path to the launch file to include.
+        launch_arguments (dict): The launch arguments to pass to the included launch file.
+    """
 
     def __init__(self, launch_description_source: str, launch_arguments: dict = None):
+        """Initializes the RegisteredLaunchDescription with a unique group id.
+
+        This class extends the IncludeLaunchDescription to automatically register a unique group id for the included launch file.
+
+        Args:
+            launch_description_source (str): The path to the launch file to include.
+            launch_arguments (dict, optional): The launch arguments to pass to the included launch file. Defaults to None.
+        """
         if launch_arguments is None:
             launch_arguments = {}
         self.group_id = Register.get_unique_group_id()
@@ -36,7 +49,20 @@ class RegisteredLaunchDescription(IncludeLaunchDescription):
 
 
 class Register:
-    """A class to register the individual processes from launch files, to ensure a desired launch order."""
+    """A class to register the individual processes from launch files, to ensure a desired launch order.
+
+    This class is used to register actions that should be started in a specific order, based on the order of registration.
+    It uses a static list to keep track of the registered actions and their order.
+    The actions can be of type Node or ExecuteProcess, and can be registered to start on specific events, such as on start, on exit, or on log messages.
+    The class also provides methods to reset the register, get the next action to start, and group registered launch descriptions together.
+
+    Attributes:
+        group_id (int): A unique identifier for the group of registered actions.
+        register (list): A list of registered actions, which can be of type Node or ExecuteProcess, or a string representing a group.
+        actions (int): The total number of actions registered.
+        started (int): The number of actions that have been started.
+        all_started (bool): A flag indicating whether all registered actions have been started.
+    """
 
     group_id = 0
     register: list[Union["Register", str]] = []
@@ -46,7 +72,11 @@ class Register:
 
     @staticmethod
     def get_unique_group_id() -> str:
-        """Get a unique group id based on a ascending counter."""
+        """Get a unique group id based on a ascending counter.
+
+        Returns:
+            str: A unique group id in the format "group_{id}".
+        """
         Register.group_id += 1
         return f"group_{Register.group_id}"
 
@@ -60,12 +90,14 @@ class Register:
 
     @staticmethod
     def next(*_: any) -> Node | ExecuteProcess:
-        """
-        Returns the executable of the next registered item that should start.
+        """Returns the executable of the next registered item that should start.
 
         This item is located at position 1 of the register list, since position 0 contains the initial register that starts the chain.
         An item can also be a string representing a group. Therefore we pop until the item at position 1 is of type Register.
         There are no registered items left to start when the length of the register list equals 1, so then we return en empty launch description.
+
+        Returns:
+            Node | ExecuteProcess: The action to start next, which can be a Node or ExecuteProcess.
         """
         item = None
         Register.started += 1
@@ -83,10 +115,16 @@ class Register:
     def group(
         launch_description: RegisteredLaunchDescription, context: LaunchContext
     ) -> RegisteredLaunchDescription:
-        """
-        Adds a the group id of the included launch_description to the register.
+        """Adds a the group id of the included launch_description to the register.
 
         This enables the items of the included launch description to register in the right order later.
+
+        Args:
+            launch_description (RegisteredLaunchDescription): The launch description to register.
+            context (LaunchContext): The launch context to get the group id from.
+
+        Returns:
+            RegisteredLaunchDescription: The launch description with the group id registered.
         """
         name = launch_description.group_id
         group = context.launch_configurations.get(CONF_NAME)
@@ -102,10 +140,18 @@ class Register:
     def connect_context(
         groups: list[RegisteredLaunchDescription],
     ) -> LaunchDescription:
-        """
-        Returns a LaunchDescription of an OpaqueFunction, so that LaunchContext is available.
+        """Returns a LaunchDescription of an OpaqueFunction, so that LaunchContext is available.
 
         This LaunchContext is required for the Register methods to correctly link the different groups of included launch files.
+
+        Args:
+            groups (list[RegisteredLaunchDescription]): A list of RegisteredLaunchDescription objects to be included in the launch description.
+
+        Returns:
+            LaunchDescription: A LaunchDescription containing an OpaqueFunction that sets up the launch items.
+
+        Raises:
+            TypeError: If any of the items in the groups list is not an instance of RegisteredLaunchDescription.
         """
 
         def launch_setup(
@@ -123,6 +169,7 @@ class Register:
         return LaunchDescription([opaque_function])
 
     def __init__(self):
+        """Initializes the Register class with default values."""
         self.action: Union[Node | ExecuteProcess]
 
         self.is_started = False
@@ -132,7 +179,17 @@ class Register:
     def on_start(
         cls, action: Union[Node, ExecuteProcess], context: LaunchContext
     ) -> LaunchDescription:
-        """Registers the given action to be ready directly on start."""
+        """Registers the given action to be ready directly on start.
+
+        This method is used to register an action that should be started immediately when the launch file is executed.
+
+        Args:
+            action (Union[Node, ExecuteProcess]): The action to register, which can be a Node or ExecuteProcess.
+            context (LaunchContext): The launch context to get the group id from.
+
+        Returns:
+            LaunchDescription: A launch description containing the action and an event handler to trigger the next action.
+        """
         register = cls()
         event_handler = RegisterEventHandler(
             OnProcessStart(target_action=action, on_start=Register.next)
@@ -143,7 +200,17 @@ class Register:
     def on_exit(
         cls, action: Union[Node, ExecuteProcess], context: LaunchContext
     ) -> LaunchDescription:
-        """Registers the given action to be ready on exit."""
+        """Registers the given action to be ready on exit.
+
+        This method is used to register an action that should be started when the specified action exits.
+
+        Args:
+            action (Union[Node, ExecuteProcess]): The action to register, which can be a Node or ExecuteProcess.
+            context (LaunchContext): The launch context to get the group id from.
+
+        Returns:
+            LaunchDescription: A launch description containing the action and an event handler to trigger the next action on exit.
+        """
         register = cls()
         event_handler = RegisterEventHandler(
             OnProcessExit(target_action=action, on_exit=Register.next)
@@ -154,7 +221,18 @@ class Register:
     def on_log(
         cls, action: Union[Node, ExecuteProcess], log: str, context: LaunchContext
     ) -> LaunchDescription:
-        """Registers the given action to be ready when logging the given log message."""
+        """Registers the given action to be ready when logging the given log message.
+
+         This method is used to register an action that should be started when a specific log message is captured.
+
+        Args:
+            action (Union[Node, ExecuteProcess]): The action to register, which can be a Node or ExecuteProcess.
+            log (str): The log message to capture before starting the action.
+            context (LaunchContext): The launch context to get the group id from.
+
+        Returns:
+            LaunchDescription: A launch description containing the action and an event handler to trigger the next action when the log message is captured.
+        """
         register = cls()
         register.log = log
         event_handler = RegisterEventHandler(
@@ -164,7 +242,14 @@ class Register:
         return register.insert_action(action, event_handler, context)
 
     def process_io(self, event: ProcessIO) -> None:
-        """Returns the next register to start if the defined log is captured."""
+        """Returns the next register to start if the defined log is captured.
+
+        This method is called when a log message is captured from the action's stderr.
+        If the log message contains the defined log, it sets the started flag to True and returns the next action to start.
+
+        Args:
+            event (ProcessIO): The event containing the log message.
+        """
         if self.is_started:
             return
         if self.log in event.text.decode():
@@ -177,14 +262,20 @@ class Register:
         event_handler: RegisterEventHandler,
         context: LaunchContext,
     ) -> LaunchDescription:
-        """
-        Inserts the action in the register and returns a launch description.
+        """Inserts the action in the register and returns a launch description.
 
         If a group is defined, the index is defined based on the index of the group.
         Otherwise, the index is simply the length of the register, so that the item is appended at the end.
-
         A launch description is returned with the event_handler.
         If the item is the first action to start, the launch_description also contains the action to trigger the chain reaction.
+
+        Args:
+            action (Union[Node, ExecuteProcess]): The action to register, which can be a Node or ExecuteProcess.
+            event_handler (RegisterEventHandler): The event handler to trigger the next action.
+            context (LaunchContext): The launch context to get the group id from.
+
+        Returns:
+            LaunchDescription: A launch description containing the action and the event handler.
         """
         self.action = action
         group = context.launch_configurations.get(CONF_NAME)
@@ -201,7 +292,14 @@ class Register:
 
 
 def log_progress(action: Union[Node, ExecuteProcess] = None) -> None:
-    """Log the start (INIT), progress ([started]/[registerd]) and when finished (ALL READY)."""
+    """Logs the progress of the registered actions.
+
+    This function logs the current status of the registered actions, including how many actions have been started and the total number of actions.
+    If no action is provided, it logs that all actions have been started.
+
+    Args:
+        action (Union[Node, ExecuteProcess], optional): The action that has just started. Defaults to None.
+    """
     if Register.started == 0:
         msg = "[START] "
     else:

--- a/ros2_ws/src/rcdt_utilities/rcdt_utilities/test_utils.py
+++ b/ros2_ws/src/rcdt_utilities/rcdt_utilities/test_utils.py
@@ -199,6 +199,9 @@ def call_express_pose_in_other_frame(
         target_frame (str): The frame to express the pose in.
         timeout (float): Timeout for waiting on service and result.
 
+    Raises:
+        RuntimeError: If the service call fails or times out.
+
     Returns:
         ExpressPoseInOtherFrame.Response: The response containing the transformed pose.
     """

--- a/ros2_ws/src/rcdt_utilities/src_py/manipulate_pose.py
+++ b/ros2_ws/src/rcdt_utilities/src_py/manipulate_pose.py
@@ -21,7 +21,16 @@ ros_logger = logging.get_logger(__name__)
 
 
 class ManipulatePose(Node):
+    """Node to manipulate poses in different frames and apply transformations.
+
+    Atributes:
+        tf_buffer (Buffer): Buffer to store transformations.
+        tf_listener (TransformListener): Listener to receive transformations.
+
+    """
+
     def __init__(self):
+        """Initialize the ManipulatePose node."""
         super().__init__("manipulate_pose")
 
         self.tf_buffer = Buffer()
@@ -42,6 +51,15 @@ class ManipulatePose(Node):
         request: ExpressPoseInOtherFrame.Request,
         response: ExpressPoseInOtherFrame.Response,
     ) -> ExpressPoseInOtherFrame.Response:
+        """Express a pose in another frame.
+
+        Args:
+            request (ExpressPoseInOtherFrame.Request): The request containing the pose and target frame.
+            response (ExpressPoseInOtherFrame.Response): The response to be filled with the transformed pose.
+
+        Returns:
+            ExpressPoseInOtherFrame.Response: The response containing the transformed pose and success status.
+        """
         source_frame = request.pose.header.frame_id
         target_frame = request.target_frame
 
@@ -62,6 +80,15 @@ class ManipulatePose(Node):
     def transform_pose(
         self, request: TransformPose.Request, response: TransformPose.Response
     ) -> TransformPose.Response:
+        """Transform a pose using a given transformation.
+
+        Args:
+            request (TransformPose.Request): The request containing the pose and transformation.
+            response (TransformPose.Response): The response to be filled with the transformed pose.
+
+        Returns:
+            TransformPose.Response: The response containing the transformed pose and success status.
+        """
         response.pose = apply_transform(request.pose, request.transform)
         response.success = True
         return response
@@ -69,12 +96,30 @@ class ManipulatePose(Node):
     def transform_pose_relative(
         self, request: TransformPose.Request, response: TransformPose.Response
     ) -> TransformPose.Response:
+        """Transform a pose relative to its current position using a given transformation.
+
+        Args:
+            request (TransformPose.Request): The request containing the pose and transformation.
+            response (TransformPose.Response): The response to be filled with the transformed pose.
+
+        Returns:
+            TransformPose.Response: The response containing the transformed pose and success status.
+        """
         response.pose = apply_transform_relative(request.pose, request.transform)
         response.success = True
         return response
 
 
 def apply_transform(pose: PoseStamped, transform: Transform) -> PoseStamped:
+    """Apply a transformation to a PoseStamped object.
+
+    Args:
+        pose (PoseStamped): The pose to be transformed.
+        transform (Transform): The transformation to apply.
+
+    Returns:
+        PoseStamped: The transformed pose.
+    """
     transform_stamped = TransformStamped()
     transform_stamped.transform = transform
     transform_stamped.header = pose.header
@@ -82,6 +127,15 @@ def apply_transform(pose: PoseStamped, transform: Transform) -> PoseStamped:
 
 
 def apply_transform_relative(pose: PoseStamped, transform: Transform) -> PoseStamped:
+    """Apply a transformation to a PoseStamped object relative to its current position.
+
+    Args:
+        pose (PoseStamped): The pose to be transformed.
+        transform (Transform): The transformation to apply.
+
+    Returns:
+        PoseStamped: The transformed pose with the original position added back.
+    """
     start_position = copy(pose.pose.position)
     pose.pose.position = Point()
     pose = apply_transform(pose, transform)
@@ -92,6 +146,11 @@ def apply_transform_relative(pose: PoseStamped, transform: Transform) -> PoseSta
 
 
 def main(args: str = None) -> None:
+    """Main function to initialize the ROS 2 node and spin it.
+
+    Args:
+        args (str, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
     node = ManipulatePose()
     spin_node(node)

--- a/ros2_ws/src/rcdt_utilities/src_py/manipulate_pose.py
+++ b/ros2_ws/src/rcdt_utilities/src_py/manipulate_pose.py
@@ -77,8 +77,9 @@ class ManipulatePose(Node):
         response.success = True
         return response
 
+    @staticmethod
     def transform_pose(
-        self, request: TransformPose.Request, response: TransformPose.Response
+        request: TransformPose.Request, response: TransformPose.Response
     ) -> TransformPose.Response:
         """Transform a pose using a given transformation.
 
@@ -93,8 +94,9 @@ class ManipulatePose(Node):
         response.success = True
         return response
 
+    @staticmethod
     def transform_pose_relative(
-        self, request: TransformPose.Request, response: TransformPose.Response
+        request: TransformPose.Request, response: TransformPose.Response
     ) -> TransformPose.Response:
         """Transform a pose relative to its current position using a given transformation.
 


### PR DESCRIPTION
## Description

This PR strengthens our linting configuration by expanding Ruff’s rule set to include docstring checks and Google‐style pydocstyle enforcement. 

- Adds D (docstring) and DOC checks to select, enabling pydocstyle rules D100–D107 and related formatting checks.
- Ignores only the very specific docstring exemptions (D100, D104) where top-level packages or modules intentionally lack docstrings.
- Enables preview mode for Ruff to try out upcoming rule behavior, like pydoclint style linting.
- Configures the Google convention under tool.ruff.lint.pydocstyle for consistent Args:, Returns:, and blank‐line formatting.

Fixes: #150 

## Testing

CI pipeline passed

## Documentation

- [ ] I have updated the documentation (if necessary)

## Additional Notes
Preview mode may introduce new rules; we’ll monitor CI for any unexpected failures and adjust the config as needed. 