### PR TITLE
Add publish_for_duration utility function and update tests to use it

### DIFF
--- a/ros2_ws/src/rcdt_franka/rcdt_franka/test/end_to_end/base_franka.py
+++ b/ros2_ws/src/rcdt_franka/rcdt_franka/test/end_to_end/base_franka.py
@@ -9,6 +9,7 @@ from rcdt_utilities.launch_utils import assert_for_message
 from rcdt_utilities.test_utils import (
     assert_joy_topic_switch,
     assert_movements_with_joy,
+    publish_for_duration,
     wait_for_register,
     wait_for_subscriber,
     wait_until_reached_joint,
@@ -65,7 +66,10 @@ def get_tests() -> dict:
 
         msg = Joy()
         msg.buttons = buttons
-        pub.publish(msg)
+
+        publish_for_duration(
+            node=test_node, publisher=pub, msg=msg, publish_duration=1, rate_sec=0.1
+        )
 
         reached_goal, joint_value = wait_until_reached_joint(
             namespace="franka",

--- a/ros2_ws/src/rcdt_franka/rcdt_franka/test/end_to_end/base_franka.py
+++ b/ros2_ws/src/rcdt_franka/rcdt_franka/test/end_to_end/base_franka.py
@@ -67,9 +67,7 @@ def get_tests() -> dict:
         msg = Joy()
         msg.buttons = buttons
 
-        publish_for_duration(
-            node=test_node, publisher=pub, msg=msg
-        )
+        publish_for_duration(node=test_node, publisher=pub, msg=msg)
 
         reached_goal, joint_value = wait_until_reached_joint(
             namespace="franka",

--- a/ros2_ws/src/rcdt_franka/rcdt_franka/test/end_to_end/base_franka.py
+++ b/ros2_ws/src/rcdt_franka/rcdt_franka/test/end_to_end/base_franka.py
@@ -68,7 +68,7 @@ def get_tests() -> dict:
         msg.buttons = buttons
 
         publish_for_duration(
-            node=test_node, publisher=pub, msg=msg, publish_duration=1, rate_sec=0.1
+            node=test_node, publisher=pub, msg=msg
         )
 
         reached_goal, joint_value = wait_until_reached_joint(

--- a/ros2_ws/src/rcdt_panther/rcdt_panther/test/integration/test_panther_core.py
+++ b/ros2_ws/src/rcdt_panther/rcdt_panther/test/integration/test_panther_core.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import time
 
 import launch_pytest
 import pytest
@@ -65,9 +64,7 @@ def test_driving(test_node: Node, timeout: int) -> None:
     msg = Twist()
     msg.linear.x = 1.0
 
-    publish_for_duration(
-        node=test_node, publisher=pub, msg=msg
-    )
+    publish_for_duration(node=test_node, publisher=pub, msg=msg)
 
     joint_value_after_driving = get_joint_position(
         "panther", "fl_wheel_joint", timeout=timeout

--- a/ros2_ws/src/rcdt_panther/rcdt_panther/test/integration/test_panther_core.py
+++ b/ros2_ws/src/rcdt_panther/rcdt_panther/test/integration/test_panther_core.py
@@ -66,10 +66,8 @@ def test_driving(test_node: Node, timeout: int) -> None:
     msg.linear.x = 1.0
 
     publish_for_duration(
-        node=test_node, publisher=pub, msg=msg, publish_duration=1, rate_sec=0.1
+        node=test_node, publisher=pub, msg=msg
     )
-
-    time.sleep(1)  # give the panther some time to move
 
     joint_value_after_driving = get_joint_position(
         "panther", "fl_wheel_joint", timeout=timeout

--- a/ros2_ws/src/rcdt_panther/rcdt_panther/test/integration/test_panther_core.py
+++ b/ros2_ws/src/rcdt_panther/rcdt_panther/test/integration/test_panther_core.py
@@ -13,6 +13,7 @@ from rcdt_utilities.register import Register, RegisteredLaunchDescription
 from rcdt_utilities.test_utils import (
     call_trigger_service,
     get_joint_position,
+    publish_for_duration,
     wait_for_register,
     wait_for_subscriber,
 )
@@ -63,7 +64,10 @@ def test_driving(test_node: Node, timeout: int) -> None:
 
     msg = Twist()
     msg.linear.x = 1.0
-    pub.publish(msg)
+
+    publish_for_duration(
+        node=test_node, publisher=pub, msg=msg, publish_duration=1, rate_sec=0.1
+    )
 
     time.sleep(1)  # give the panther some time to move
 

--- a/ros2_ws/src/rcdt_utilities/rcdt_utilities/test_utils.py
+++ b/ros2_ws/src/rcdt_utilities/rcdt_utilities/test_utils.py
@@ -4,7 +4,7 @@
 
 
 import time
-from typing import Callable, Type
+from typing import Any, Callable, Type
 
 import pytest
 import rclpy
@@ -40,7 +40,7 @@ def add_tests_to_class(cls: type, tests: dict[str, Callable]) -> None:
 
 
 def publish_for_duration(
-    node: Node, publisher: Publisher, msg: Joy, publish_duration: float, rate_sec: float
+    node: Node, publisher: Publisher, msg: Any, publish_duration: float, rate_sec: float
 ) -> None:
     """
     Publishes a message at a specified rate for a given duration.

--- a/ros2_ws/src/rcdt_utilities/rcdt_utilities/test_utils.py
+++ b/ros2_ws/src/rcdt_utilities/rcdt_utilities/test_utils.py
@@ -40,7 +40,11 @@ def add_tests_to_class(cls: type, tests: dict[str, Callable]) -> None:
 
 
 def publish_for_duration(
-    node: Node, publisher: Publisher, msg: Any, publish_duration: float= 1.0, rate_sec: float = 0.1
+    node: Node,
+    publisher: Publisher,
+    msg: Any,
+    publish_duration: float = 1.0,
+    rate_sec: float = 0.1,
 ) -> None:
     """
     Publishes a message at a specified rate for a given duration.
@@ -197,7 +201,10 @@ def assert_joy_topic_switch(
     )
 
     start_time = time.monotonic()
-    while result.get("state") != expected_topic and time.monotonic() - start_time < timeout:
+    while (
+        result.get("state") != expected_topic
+        and time.monotonic() - start_time < timeout
+    ):
         rclpy.spin_once(node, timeout_sec=1)
         time.sleep(0.1)
 

--- a/ros2_ws/src/rcdt_utilities/rcdt_utilities/test_utils.py
+++ b/ros2_ws/src/rcdt_utilities/rcdt_utilities/test_utils.py
@@ -40,7 +40,7 @@ def add_tests_to_class(cls: type, tests: dict[str, Callable]) -> None:
 
 
 def publish_for_duration(
-    node: Node, publisher: Publisher, msg: Any, publish_duration: float, rate_sec: float
+    node: Node, publisher: Publisher, msg: Any, publish_duration: float= 1.0, rate_sec: float = 0.1
 ) -> None:
     """
     Publishes a message at a specified rate for a given duration.
@@ -65,8 +65,8 @@ def wait_for_subscriber(pub: Publisher, timeout: int) -> None:
     This avoids problems in tests where a publisher is created and instantly sends a message,
     before the intended subscriber is ready.
     """
-    start_time = time.time()
-    while pub.get_subscription_count() == 0 and time.time() - start_time < timeout:
+    start_time = time.monotonic()
+    while pub.get_subscription_count() == 0 and time.monotonic() - start_time < timeout:
         time.sleep(0.1)
 
 
@@ -196,8 +196,8 @@ def assert_joy_topic_switch(
         node=node, publisher=pub, msg=msg, publish_duration=1, rate_sec=0.1
     )
 
-    start_time = time.time()
-    while result.get("state") != expected_topic and time.time() - start_time < timeout:
+    start_time = time.monotonic()
+    while result.get("state") != expected_topic and time.monotonic() - start_time < timeout:
         rclpy.spin_once(node, timeout_sec=1)
         time.sleep(0.1)
 
@@ -309,8 +309,8 @@ def wait_until_reached_joint(
 
     Returns:
         Tuple[bool, float]: (True, joint_value) if target reached; otherwise (False"""
-    end_time = time.time() + timeout_sec
-    while time.time() < end_time:
+    end_time = time.monotonic() + timeout_sec
+    while time.monotonic() < end_time:
         try:
             joint_value = get_joint_position(
                 namespace=namespace, joint=joint, timeout=timeout_sec
@@ -336,8 +336,8 @@ def wait_for_register(timeout: int) -> None:
     Therefore, the while loop has it's own timeout which also uses the defined pytest-timeout variable.
     """
     logger = get_logger("wait_for_register")
-    start = time.time()
-    while not Register.all_started and time.time() - start < timeout:
+    start = time.monotonic()
+    while not Register.all_started and time.monotonic() - start < timeout:
         time.sleep(1)
     if Register.all_started:
         logger.info(colored("Register is ready, start testing!", "green"))


### PR DESCRIPTION
## Description

Published messages can get lost, but in our test we only send one and thus tests can fail. Now we can send multiple messages over a duration of time. 

Fixes: #183 

## Testing

Tests succeed. 

## Documentation

- [x] I have updated the documentation (if necessary)

## Additional Notes

Any relevant screenshots, logs, or context.