### PR TITLE
149 seperating the docker build cache from pr branches and main

### DIFF
--- a/.github/workflows/docker-and-workspace.yml
+++ b/.github/workflows/docker-and-workspace.yml
@@ -54,6 +54,7 @@ jobs:
     uses: ./.github/workflows/reusable-docker.yml
     with:
       container-image: rcdt/robotics:${{ needs.get-image-tag.outputs.tag }}
+      cache-tag: build-cache-${{ needs.get-image-tag.outputs.tag }}
     secrets: inherit
   workspace:
     needs: [get-image-tag, docker]

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -10,6 +10,9 @@ on:
       container-image:
         type: string
         required: true
+      cache-tag:
+        type: string
+        required: true
 
 jobs:
   deploy-image:

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -30,5 +30,7 @@ jobs:
           context: ./dockerfiles
           file: ./dockerfiles/rcdt_robotics.Dockerfile
           tags: ${{ inputs.container-image}}
-          cache-from: type=registry,ref=rcdt/robotics:build-cache
-          cache-to: type=registry,ref=rcdt/robotics:build-cache,mode=max
+          cache-from: |
+            type=registry,ref=rcdt/robotics:build-cache-main
+            type=registry,ref=rcdt/robotics:${{ inputs.cache-tag }}
+          cache-to: type=registry,ref=rcdt/robotics:${{ inputs.cache-tag }},mode=max


### PR DESCRIPTION
## Description

Added a cache-tag support for caching the current branch and the main branch. 

Fixes: #149 

## Testing

Explain how you tested your changes.

## Additional Notes

[Reference link](https://docs.docker.com/build/cache/backends/#registry)