### PR TITLE
Update build cache reference to use 'build-cache-latest'

### DIFF
--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -35,5 +35,5 @@ jobs:
           tags: ${{ inputs.container-image}}
           cache-from: |
             type=registry,ref=rcdt/robotics:${{ inputs.cache-tag }}
-            type=registry,ref=rcdt/robotics:build-cache-main
+            type=registry,ref=rcdt/robotics:build-cache-latest
           cache-to: type=registry,ref=rcdt/robotics:${{ inputs.cache-tag }},mode=max


### PR DESCRIPTION
## Description

This hotfix is for the typo that the main branch gets tagged with latest instead of main, so this will create a cache hit.