### PR TITLE
Add ZED2i support

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - "/tmp/.X11-unix:/tmp/.X11-unix"
       - "${HOME}/.vscode-server:/home/rcdt/.vscode-server"
       - "../:/home/rcdt/rcdt_robotics/"
+      - ../.cache/zed/resources:/usr/local/zed/resources
+      - ../.cache/zed/settings:/usr/local/zed/settings
       - "../.personal.bashrc:/home/rcdt/.personal.bashrc"
       - "../.env:/home/rcdt/.env"
       - "../pyproject.toml:/home/rcdt/pyproject.toml"

--- a/dockerfiles/install_scripts/core_packages.sh
+++ b/dockerfiles/install_scripts/core_packages.sh
@@ -14,7 +14,8 @@ apt install -y \
     git-lfs \
     htop \
     nano \
-    python3-pip
+    python3-pip \
+    zstd
 
 apt install -y \
     ros-$ROS_DISTRO-launch-pytest \

--- a/dockerfiles/install_scripts/zed_sdk.sh
+++ b/dockerfiles/install_scripts/zed_sdk.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -i
+
+# SPDX-FileCopyrightText: Alliander N. V.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Based on dockerfile of ZED-ros2-wrapper at: 
+# https://github.com/stereolabs/zed-ros2-wrapper/blob/e9f54907fbf41ee9ce5d54f3bb694af93dad8bb3/docker/Dockerfile.desktop-humble
+
+set -e
+
+UBUNTU_RELEASE_YEAR=24      
+CUDA_MAJOR=12              
+CUDA_MINOR=9                
+ZED_SDK_MAJOR=5
+ZED_SDK_MINOR=0             
+
+###  CUDA “version.txt” marker 
+echo "CUDA Version ${CUDA_MAJOR}.${CUDA_MINOR}.0" > /usr/local/cuda/version.txt || true
+
+###  Download + install ZED SDK 
+installer="ZED_SDK_Ubuntu${UBUNTU_RELEASE_YEAR}_cuda${CUDA_MAJOR}.${CUDA_MINOR}.run"
+sdk_url="https://download.stereolabs.com/zedsdk/${ZED_SDK_MAJOR}.${ZED_SDK_MINOR}/cu${CUDA_MAJOR}/ubuntu${UBUNTU_RELEASE_YEAR}"
+
+echo "Downloading ${sdk_url}  →  ${installer} ..."
+wget -q -O "${installer}" "${sdk_url}"
+chmod +x "${installer}"
+
+echo "Running installer …"
+./"${installer}" -- silent 
+
+chmod -R u+rwX,go+rX /usr/local/zed
+
+rm -f "${installer}"
+rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/install_scripts/zed_wrapper.sh
+++ b/dockerfiles/install_scripts/zed_wrapper.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -i
+
+# SPDX-FileCopyrightText: Alliander N. V.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+source /home/$UNAME/.bashrc
+apt update
+
+cd /home/$UNAME
+mkdir zed_ws
+cd /home/$UNAME/zed_ws
+git clone -b jazzy https://github.com/stereolabs/zed-ros2-wrapper.git src/zed_ros2_wrapper
+
+sudo apt update
+rosdep update
+rosdep install --from-paths src --rosdistro $ROS_DISTRO -y -r
+colcon build --symlink-install --cmake-args=-DCMAKE_BUILD_TYPE=Release
+
+echo "source /home/$UNAME/zed_ws/install/setup.bash" >>/home/$UNAME/.bashrc

--- a/dockerfiles/rcdt_robotics.Dockerfile
+++ b/dockerfiles/rcdt_robotics.Dockerfile
@@ -11,6 +11,12 @@ RUN ./ros2_jazzy.sh
 COPY ./install_scripts/core_packages.sh .
 RUN ./core_packages.sh
 
+COPY ./install_scripts/zed_sdk.sh .
+RUN ./zed_sdk.sh
+
+COPY ./install_scripts/zed_wrapper.sh .
+RUN ./zed_wrapper.sh
+
 COPY ./install_scripts/franka_ros2.sh .
 RUN ./franka_ros2.sh
 

--- a/docs/content/platforms.md
+++ b/docs/content/platforms.md
@@ -104,6 +104,18 @@ A Realsense camera can be launched in simulation by creating a configuration wit
 
 One can use a Realsense by connecting it with the host device using USB.
 
+## ZED
+
+![ZED](../img/zed/ZED.png)
+
+### Simulation Zed
+
+A ZED camera can be launched in simulation by creating a configuration with an *Camera* of type *zed*.
+
+### Hardware Zed
+
+A ZED camera can be used by connecting it to the host device via USB. To allow non-root users to access the camera, UDEV rules must be installed on the host machine. The required script can be found [here](https://gist.github.com/adujardin/2d5ce8f000fc6a7bd40bee2709749ff8).
+
 ## Velodyne
 
 ![Velodyne](../img/velodyne/velodyne.png)

--- a/docs/img/zed/ZED.png
+++ b/docs/img/zed/ZED.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e8ff49a59102c8c0af47f2b84ff852b35ff24e697358d9174d628e0abb10d58
+size 140557

--- a/docs/img/zed/ZED.png.license
+++ b/docs/img/zed/ZED.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Alliander N. V.
+
+SPDX-License-Identifier: Apache-2.0

--- a/ros2_ws/src/rcdt_launch/launch/robots.launch.py
+++ b/ros2_ws/src/rcdt_launch/launch/robots.launch.py
@@ -22,11 +22,13 @@ configuration_arg = LaunchArgument(
         "",
         "lidar",
         "realsense",
+        "zed",
         "franka",
         "franka_double",
         "franka_realsense",
         "panther",
         "panther_realsense",
+        "panther_zed",
         "panther_lidar",
         "mm",
         "mm_lidar",
@@ -34,7 +36,7 @@ configuration_arg = LaunchArgument(
 )
 
 
-def launch_setup(context: LaunchContext) -> list:  # noqa: PLR0915
+def launch_setup(context: LaunchContext) -> list:  # noqa: PLR0912, PLR0915
     """Setup the launch description for the Panther robot.
 
     Args:
@@ -63,6 +65,8 @@ def launch_setup(context: LaunchContext) -> list:  # noqa: PLR0915
             Lidar("velodyne", [0, 0, 0.5])
         case "realsense":
             Camera("realsense", [0, 0, 0.5])
+        case "zed":
+            Camera("zed", [0, 0, 0.5], namespace="zed")
         case "franka":
             if not use_sim:
                 Rviz.load_motion_planning_plugin = True
@@ -80,6 +84,9 @@ def launch_setup(context: LaunchContext) -> list:  # noqa: PLR0915
         case "panther_realsense":
             panther = Vehicle("panther", [0, 0, 0.2])
             Camera("realsense", [0, 0, 0.5], parent=panther)
+        case "panther_zed":
+            panther = Vehicle("panther", [0, 0, 0.2])
+            Camera("zed", [0, 0, 0.5], parent=panther)
         case "panther_lidar":
             panther = Vehicle("panther", [0, 0, 0.2], navigation=True)
             Lidar("velodyne", [0.13, -0.13, 0.35], parent=panther)

--- a/ros2_ws/src/rcdt_sensors/CMakeLists.txt
+++ b/ros2_ws/src/rcdt_sensors/CMakeLists.txt
@@ -23,7 +23,7 @@ install(
 
 # Shared folders:
 install(
-  DIRECTORY launch urdf
+  DIRECTORY launch urdf config
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/ros2_ws/src/rcdt_sensors/config/common_stereo.yaml
+++ b/ros2_ws/src/rcdt_sensors/config/common_stereo.yaml
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Alliander N. V.
+#
+# SPDX-License-Identifier: Apache-2.0
+---
+/**:
+    ros__parameters:
+        use_sim_time: false # Set to `true` only if there is a publisher for the simulated clock to the `/clock` topic. Normally used in simulation mode.
+
+        simulation:
+            sim_enabled: false # Set to `true` to enable the simulation mode and connect to a simulation server
+            sim_address: '127.0.0.1' # The connection address of the simulation server. See the documentation of the supported simulation plugins for more information.
+            sim_port: 30000 # The connection port of the simulation server. See the documentation of the supported simulation plugins for more information.
+
+        svo:
+            use_svo_timestamps: true # Use the SVO timestamps to publish data. If false, data will be published at the system time.
+            publish_svo_clock: false # [overwritten by launch file options] When use_svo_timestamps is true allows to publish the SVO clock to the `/clock` topic. This is useful for synchronous rosbag playback.
+            svo_loop: false # Enable loop mode when using an SVO as input source. NOTE: ignored if SVO timestamping is used
+            svo_realtime: false # if true the SVO will be played trying to respect the original framerate eventually skipping frames, otherwise every frame will be processed respecting the `pub_frame_rate` setting
+            play_from_frame: 0 # Start playing the SVO from a specific frame
+            replay_rate: 1.0 # Replay rate for the SVO when not used in realtime mode (between [0.10-5.0])
+
+        general:
+            camera_timeout_sec: 5
+            camera_max_reconnect: 5
+            camera_flip: false
+            self_calib: true # Enable the self-calibration process at camera opening. See https://www.stereolabs.com/docs/api/structsl_1_1InitParameters.html#affeaa06cfc1d849e311e484ceb8edcc5
+            serial_number: 0 # overwritten by launch file
+            pub_resolution: 'CUSTOM' # The resolution used for image and depth map publishing. 'NATIVE' to use the same `general.grab_resolution` - `CUSTOM` to apply the `general.pub_downscale_factor` downscale factory to reduce bandwidth in transmission
+            pub_downscale_factor: 2.0 # rescale factor used to rescale image before publishing when 'pub_resolution' is 'CUSTOM'
+            pub_frame_rate: 15.0 # [DYNAMIC] Frequency of publishing of visual images and depth data (not the Point Cloud, see 'depth.point_cloud_freq'). This value must be equal or less than the camera framerate.
+            enable_image_validity_check: 1 # [SDK5 required] Sets the image validity check. If set to 1, the SDK will check if the frames are valid before processing.
+            gpu_id: -1
+            optional_opencv_calibration_file: '' # Optional path where the ZED SDK can find a file containing the calibration information of the camera computed by OpenCV. Read the ZED SDK documentation for more information: https://www.stereolabs.com/docs/api/structsl_1_1InitParameters.html#a9eab2753374ef3baec1d31960859ba19
+            async_image_retrieval: false # If set to true will camera image retrieve at a framerate different from \ref grab() application framerate. This is useful for recording SVO or sending camera stream at different rate than application.
+            # Other parameters are defined, according to the camera model, in the 'zed.yaml', 'zedm.yaml', 'zed2.yaml', 'zed2i.yaml'
+            # 'zedx.yaml', 'zedxmini.yaml', 'virtual.yaml' files
+
+        video:
+            saturation: 4 # [DYNAMIC]
+            sharpness: 4 # [DYNAMIC]
+            gamma: 8 # [DYNAMIC]
+            auto_exposure_gain: true # [DYNAMIC]
+            exposure: 80 # [DYNAMIC]
+            gain: 80 # [DYNAMIC]
+            auto_whitebalance: true # [DYNAMIC]
+            whitebalance_temperature: 42 # [DYNAMIC] - [28,65] x100 - works only if `auto_whitebalance` is false
+            # Other parameters are defined, according to the camera model, in the 'zed.yaml', 'zedm.yaml', 'zed2.yaml', 'zed2i.yaml'
+            # 'zedx.yaml', 'zedxmini.yaml', 'virtual.yaml' files
+
+        sensors:
+            publish_imu_tf: false # [overwritten by launch file options] enable/disable the IMU TF broadcasting
+            sensors_image_sync: false # Synchronize Sensors messages with latest published video/depth message
+            sensors_pub_rate: 100. # frequency of publishing of sensors data. MAX: 400. - MIN: grab rate
+
+        region_of_interest:
+            automatic_roi: false # Enable the automatic ROI generation to automatically detect part of the robot in the FoV and remove them from the processing. Note: if enabled the value of `manual_polygon` is ignored
+            depth_far_threshold_meters: 2.5 # Filtering how far object in the ROI should be considered, this is useful for a vehicle for instance
+            image_height_ratio_cutoff: 0.5 # By default consider only the lower half of the image, can be useful to filter out the sky
+            #manual_polygon: '[]' # A polygon defining the ROI where the ZED SDK perform the processing ignoring the rest. Coordinates must be normalized to '1.0' to be resolution independent.
+            #manual_polygon: '[[0.25,0.33],[0.75,0.33],[0.75,0.5],[0.5,0.75],[0.25,0.5]]' # A polygon defining the ROI where the ZED SDK perform the processing ignoring the rest. Coordinates must be normalized to '1.0' to be resolution independent.
+            #manual_polygon: '[[0.25,0.25],[0.75,0.25],[0.75,0.75],[0.25,0.75]]' # A polygon defining the ROI where the ZED SDK perform the processing ignoring the rest. Coordinates must be normalized to '1.0' to be resolution independent.
+            #manual_polygon: '[[0.5,0.25],[0.75,0.5],[0.5,0.75],[0.25,0.5]]' # A polygon defining the ROI where the ZED SDK perform the processing ignoring the rest. Coordinates must be normalized to '1.0' to be resolution independent.
+            apply_to_depth: true # Apply ROI to depth processing
+            apply_to_positional_tracking: true # Apply ROI to positional tracking processing
+            apply_to_object_detection: true # Apply ROI to object detection processing
+            apply_to_body_tracking: true # Apply ROI to body tracking processing
+            apply_to_spatial_mapping: true # Apply ROI to spatial mapping processing
+
+        depth:
+            depth_mode: 'NEURAL_LIGHT' # Matches the ZED SDK setting: 'NONE', 'PERFORMANCE', 'QUALITY', 'ULTRA', 'NEURAL', 'NEURAL_PLUS' - Note: if 'NONE' all the modules that requires depth extraction are disabled by default (Pos. Tracking, Obj. Detection, Mapping, ...)
+            depth_stabilization: 30 # Forces positional tracking to start if major than 0 - Range: [0,100]
+            openni_depth_mode: false # 'false': 32bit float [meters], 'true': 16bit unsigned int [millimeters]
+            point_cloud_freq: 10.0 # [DYNAMIC] Frequency of the pointcloud publishing. This value must be equal or less than the camera framerate.
+            point_cloud_res: 'COMPACT' # The resolution used for point cloud publishing - 'COMPACT'-Standard resolution. Optimizes processing and bandwidth, 'REDUCED'-Half resolution. Low processing and bandwidth requirements
+            depth_confidence: 95 # [DYNAMIC]
+            depth_texture_conf: 100 # [DYNAMIC]
+            remove_saturated_areas: true # [DYNAMIC]
+            # Other parameters are defined, according to the camera model, in the 'zed.yaml', 'zedm.yaml', 'zed2.yaml', 'zed2i.yaml'
+            # 'zedx.yaml', 'zedxmini.yaml', 'virtual.yaml' files
+
+        pos_tracking:
+            pos_tracking_enabled: false # True to enable positional tracking from start
+            pos_tracking_mode: 'GEN_3' # Matches the ZED SDK setting: 'GEN_1', 'GEN_2', 'GEN_3'
+            imu_fusion: true # enable/disable IMU fusion. When set to false, only the optical odometry will be used.
+            publish_tf: false # [overwritten by launch file options] publish `odom -> camera_link` TF
+            publish_map_tf: false # [overwritten by launch file options] publish `map -> odom` TF
+            map_frame: 'map'
+            odometry_frame: 'odom'
+            area_memory: true # Enable to detect loop closure
+            area_file_path: '' # Path to the area memory file for relocalization and loop closure in a previously explored environment. 
+            save_area_memory_on_closing: false # Save Area memory before closing the camera if `area_file_path` is not empty. You can also use the `save_area_memory` service to save the area memory at any time.
+            reset_odom_with_loop_closure: true # Re-initialize odometry to the last valid pose when loop closure happens (reset camera odometry drift)
+            publish_3d_landmarks: true # Publish 3D landmarks used by the positional tracking algorithm
+            publish_lm_skip_frame: 5 # Publish the landmarks every X frames to reduce bandwidth. Set to 0 to publish all landmarks
+            depth_min_range: 0.0 # Set this value for removing fixed zones of the robot in the FoV of the camerafrom the visual odometry evaluation
+            set_as_static: false # If 'true' the camera will be static and not move in the environment
+            set_gravity_as_origin: true # If 'true' align the positional tracking world to imu gravity measurement. Keep the yaw from the user initial pose.
+            floor_alignment: false # Enable to automatically calculate camera/floor offset
+            initial_base_pose: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0] # Initial position of the `camera_link` frame in the map -> [X, Y, Z, R, P, Y]
+            path_pub_rate: 2.0 # [DYNAMIC] - Camera trajectory publishing frequency
+            path_max_count: -1 # use '-1' for unlimited path size
+            two_d_mode: false # Force navigation on a plane. If true the Z value will be fixed to 'fixed_z_value', roll and pitch to zero
+            fixed_z_value: 0.0 # Value to be used for Z coordinate if `two_d_mode` is true
+            transform_time_offset: 0.0 # The value added to the timestamp of `map->odom` and `odom->camera_link` transform being generated
+            reset_pose_with_svo_loop: true # Reset the camera pose the `initial_base_pose` when the SVO loop is enabled and the SVO playback reaches the end of the file.
+
+        gnss_fusion:
+            gnss_fusion_enabled: false # fuse 'sensor_msg/NavSatFix' message information into pose data
+            gnss_fix_topic: '/fix' # Name of the GNSS topic of type NavSatFix to subscribe [Default: '/gps/fix']
+            gnss_zero_altitude: false # Set to `true` to ignore GNSS altitude information
+            h_covariance_mul: 1.0 # Multiplier factor to be applied to horizontal covariance of the received fix (plane X/Y)
+            v_covariance_mul: 1.0 # Multiplier factor to be applied to vertical covariance of the received fix (Z axis)
+            publish_utm_tf: true # Publish `utm` -> `map` TF
+            broadcast_utm_transform_as_parent_frame: false # if 'true' publish `utm` -> `map` TF, otherwise `map` -> `utm`
+            enable_reinitialization: false # determines whether reinitialization should be performed between GNSS and VIO fusion when a significant disparity is detected between GNSS data and the current fusion data. It becomes particularly crucial during prolonged GNSS signal loss scenarios.
+            enable_rolling_calibration: true # If this parameter is set to true, the fusion algorithm will used a rough VIO / GNSS calibration at first and then refine it. This allow you to quickly get a fused position.
+            enable_translation_uncertainty_target: false # When this parameter is enabled (set to true), the calibration process between GNSS and VIO accounts for the uncertainty in the determined translation, thereby facilitating the calibration termination. The maximum allowable uncertainty is controlled by the 'target_translation_uncertainty' parameter.
+            gnss_vio_reinit_threshold: 5.0 # determines the threshold for GNSS/VIO reinitialization. If the fused position deviates beyond out of the region defined by the product of the GNSS covariance and the gnss_vio_reinit_threshold, a reinitialization will be triggered.
+            target_translation_uncertainty: 0.1 # defines the target translation uncertainty at which the calibration process between GNSS and VIO concludes. By default, the threshold is set at 10 centimeters.
+            target_yaw_uncertainty: 0.1 # defines the target yaw uncertainty at which the calibration process between GNSS and VIO concludes. The unit of this parameter is in radian. By default, the threshold is set at 0.1 radians.
+
+        mapping:
+            mapping_enabled: false # True to enable mapping and fused point cloud pubblication
+            resolution: 0.05 # maps resolution in meters [min: 0.01f - max: 0.2f]
+            max_mapping_range: 5.0 # maximum depth range while mapping in meters (-1 for automatic calculation) [2.0, 20.0]
+            fused_pointcloud_freq: 1.0 # frequency of the publishing of the fused colored point cloud
+            clicked_point_topic: '/clicked_point' # Topic published by Rviz when a point of the cloud is clicked. Used for plane detection
+            pd_max_distance_threshold: 0.15 # Plane detection: controls the spread of plane by checking the position difference.
+            pd_normal_similarity_threshold: 15.0 # Plane detection: controls the spread of plane by checking the angle difference.
+
+        object_detection:
+            od_enabled: false # True to enable Object Detection
+            enable_tracking: true # Whether the object detection system includes object tracking capabilities across a sequence of images.
+            detection_model: 'MULTI_CLASS_BOX_FAST' # 'MULTI_CLASS_BOX_FAST', 'MULTI_CLASS_BOX_MEDIUM', 'MULTI_CLASS_BOX_ACCURATE', 'PERSON_HEAD_BOX_FAST', 'PERSON_HEAD_BOX_ACCURATE', 'CUSTOM_YOLOLIKE_BOX_OBJECTS'
+            max_range: 20.0 # [m] Upper depth range for detections.The value cannot be greater than 'depth.max_depth'
+            filtering_mode: 1 # Filtering mode that should be applied to raw detections: 'NONE', 'NMS3D', 'NMS3D_PER_CLASS'
+            prediction_timeout: 2.0 # During this time [sec], the object will have OK state even if it is not detected. Set this parameter to 0 to disable SDK predictions
+            allow_reduced_precision_inference: false # Allow inference to run at a lower precision to improve runtime and memory usage
+            # Other parameters are defined in the 'object_detection.yaml' and 'custom_object_detection.yaml' files
+
+        body_tracking:
+            bt_enabled: false # True to enable Body Tracking
+            model: 'HUMAN_BODY_MEDIUM' # 'HUMAN_BODY_FAST', 'HUMAN_BODY_MEDIUM', 'HUMAN_BODY_ACCURATE'
+            body_format: 'BODY_38' # 'BODY_18','BODY_34','BODY_38'
+            allow_reduced_precision_inference: false # Allow inference to run at a lower precision to improve runtime and memory usage
+            max_range: 15.0 # [m] Defines a upper depth range for detections
+            body_kp_selection: 'FULL' # 'FULL', 'UPPER_BODY'
+            enable_body_fitting: false # Defines if the body fitting will be applied
+            enable_tracking: true # Defines if the object detection will track objects across images flow
+            prediction_timeout_s: 0.5 # During this time [sec], the skeleton will have OK state even if it is not detected. Set this parameter to 0 to disable SDK predictions
+            confidence_threshold: 50.0 # [DYNAMIC] - Minimum value of the detection confidence of skeleton key points [0,99]
+            minimum_keypoints_threshold: 5 # [DYNAMIC] - Minimum number of skeleton key points to be detected for a valid skeleton
+
+        stream_server:
+            stream_enabled: false # enable the streaming server when the camera is open
+            codec: 'H264' # different encoding types for image streaming: 'H264', 'H265'
+            port: 30000 # Port used for streaming. Port must be an even number. Any odd number will be rejected.
+            bitrate: 12500 # [1000 - 60000] Streaming bitrate (in Kbits/s) used for streaming. See https://www.stereolabs.com/docs/api/structsl_1_1StreamingParameters.html#a873ba9440e3e9786eb1476a3bfa536d0
+            gop_size: -1 # [max 256] The GOP size determines the maximum distance between IDR/I-frames. Very high GOP size will result in slightly more efficient compression, especially on static scenes. But latency will increase.
+            adaptative_bitrate: false # Bitrate will be adjusted depending the number of packet dropped during streaming. If activated, the bitrate can vary between [bitrate/4, bitrate].
+            chunk_size: 16084 # [1024 - 65000] Stream buffers are divided into X number of chunks where each chunk is chunk_size bytes long. You can lower chunk_size value if network generates a lot of packet lost: this will generates more chunk for a single image, but each chunk sent will be lighter to avoid inside-chunk corruption. Increasing this value can decrease latency.
+            target_framerate: 0 # Framerate for the streaming output. This framerate must be below or equal to the camera framerate. Allowed framerates are 15, 30, 60 or 100 if possible. Any other values will be discarded and camera FPS will be taken.
+
+        advanced: # WARNING: do not modify unless you are confident of what you are doing
+            # Reference documentation: https://man7.org/linux/man-pages/man7/sched.7.html
+            thread_sched_policy: 'SCHED_BATCH' # 'SCHED_OTHER', 'SCHED_BATCH', 'SCHED_FIFO', 'SCHED_RR' - NOTE: 'SCHED_FIFO' and 'SCHED_RR' require 'sudo'
+            thread_grab_priority: 50 # ONLY with 'SCHED_FIFO' and 'SCHED_RR' - [1 (LOW) z-> 99 (HIGH)] - NOTE: 'sudo' required
+            thread_sensor_priority: 70 # ONLY with 'SCHED_FIFO' and 'SCHED_RR' - [1 (LOW) z-> 99 (HIGH)] - NOTE: 'sudo' required
+            thread_pointcloud_priority: 60 # ONLY with 'SCHED_FIFO' and 'SCHED_RR' - [1 (LOW) z-> 99 (HIGH)] - NOTE: 'sudo' required
+
+        debug:
+            sdk_verbose: 1 # Set the verbose level of the ZED SDK
+            sdk_verbose_log_file: '' # Path to the file where the ZED SDK will log its messages. If empty, no file will be created. The log level can be set using the `sdk_verbose` parameter.
+            use_pub_timestamps: false # Use the current ROS time for the message timestamp instead of the camera timestamp. This is useful to test data communication latency.
+            debug_common: false
+            debug_sim: false
+            debug_video_depth: false
+            debug_camera_controls: false
+            debug_point_cloud: false
+            debug_positional_tracking: false
+            debug_gnss: false
+            debug_sensors: false
+            debug_mapping: false
+            debug_terrain_mapping: false
+            debug_object_detection: false
+            debug_body_tracking: false
+            debug_roi: false
+            debug_streaming: false
+            debug_advanced: false
+            debug_nitros: false
+            disable_nitros: false # If available, disable NITROS usage for debugging and testing purposes

--- a/ros2_ws/src/rcdt_sensors/launch/zed.launch.py
+++ b/ros2_ws/src/rcdt_sensors/launch/zed.launch.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Alliander N. V.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from launch import LaunchContext, LaunchDescription
+from launch.actions import OpaqueFunction
+from launch_ros.actions import ComposableNodeContainer, Node
+from launch_ros.descriptions import ComposableNode
+from rcdt_utilities.launch_utils import LaunchArgument, get_file_path
+from rcdt_utilities.register import Register
+
+namespace_arg = LaunchArgument("namespace", "zed")
+use_sim_arg = LaunchArgument("simulation", True, [True, False])
+
+
+def launch_setup(context: LaunchContext) -> list:
+    """Setup the launch description for the ZED camera.
+
+    Args:
+        context (LaunchContext): The launch context.
+
+    Returns:
+        list: A list of actions to be executed.
+    """
+    namespace = namespace_arg.string_value(context)
+    use_sim = use_sim_arg.bool_value(context)
+
+    # ZED Node parameters
+    common_cfg = get_file_path("rcdt_sensors", ["config"], "common_stereo.yaml")
+    camera_cfg = get_file_path("zed_wrapper", ["config"], "zed2i.yaml")
+    ffmpeg_cfg = get_file_path("zed_wrapper", ["config"], "ffmpeg.yaml")
+
+    node_parameters = [
+        common_cfg,
+        camera_cfg,
+        ffmpeg_cfg,
+        {
+            # Required identification
+            "general.camera_name": f"{namespace}/{namespace}",
+            "general.camera_model": "zed2i",
+            "general.camera_id": -1,
+            "pos_tracking.enable_tracking": False,
+            "depth.depth_stabilization": 0,
+            "pos_tracking.publish_tf": False,
+            "pos_tracking.publish_map_tf": False,
+        },
+    ]
+
+    if use_sim:
+        convert_32FC1_to_16UC1_node = Node(  # noqa: N806
+            package="rcdt_sensors",
+            executable="convert_32FC1_to_16UC1.py",
+            namespace=namespace,
+        )
+        combine_camera_topics_node = Node(
+            package="rcdt_sensors",
+            executable="combine_camera_topics.py",
+            namespace=namespace,
+        )
+        zed = LaunchDescription(
+            [
+                Register.on_start(convert_32FC1_to_16UC1_node, context),
+                Register.on_start(combine_camera_topics_node, context),
+            ]
+        )
+    else:
+        zed_node = ComposableNode(
+            package="zed_components",
+            plugin="stereolabs::ZedCamera",
+            name=namespace,
+            parameters=node_parameters,
+            remappings=[
+                (f"/{namespace}/left/camera_info", f"/{namespace}/color/camera_info"),
+                (
+                    f"/{namespace}/left/image_rect_color",
+                    f"/{namespace}/color/image_raw",
+                ),
+                (
+                    f"/{namespace}/depth/depth_registered",
+                    f"/{namespace}/depth/image_rect_raw",
+                ),
+            ],
+            extra_arguments=[{"use_intra_process_comms": True}],
+        )
+        # Define the container
+        zed_container = ComposableNodeContainer(
+            name="zed_container",
+            namespace=namespace,
+            package="rclcpp_components",
+            executable="component_container_mt",
+            composable_node_descriptions=[zed_node],
+            output="screen",
+        )
+        zed = LaunchDescription([Register.on_start(zed_container, context)])
+
+    return [zed]
+
+
+def generate_launch_description() -> LaunchDescription:
+    """Generate the launch description for the ZED camera.
+
+    Returns:
+        LaunchDescription: The launch description for the ZED camera.
+    """
+    return LaunchDescription(
+        [
+            namespace_arg.declaration,
+            use_sim_arg.declaration,
+            OpaqueFunction(function=launch_setup),
+        ]
+    )

--- a/ros2_ws/src/rcdt_sensors/urdf/rcdt_zed2i.urdf.xacro
+++ b/ros2_ws/src/rcdt_sensors/urdf/rcdt_zed2i.urdf.xacro
@@ -1,0 +1,109 @@
+<?xml version="1.0"?>
+<!--
+SPDX-FileCopyrightText: Alliander N. V.
+SPDX-License-Identifier: Apache-2.0
+-->
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="rcdt_zed2i">
+
+  <xacro:macro name="rcdt_zed2i"
+    params="
+    namespace
+    parent:=world
+    name:=camera
+    gazebo:=true
+    model:=zed2i
+    enable_gnss:=false
+    align:=left
+    xyz:='0 0 0' 
+    rpy:='0 0 0' 
+    ">
+
+    <!-- Gazebo requires a joint to a link called "world" for statically mounted robots -->
+    <xacro:if value="${parent != ''}">
+      <xacro:if value="${parent == 'world'}">
+        <link name="${parent}" />
+        <joint name="${parent}_joint" type="fixed">
+          <parent link="${parent}" />
+          <child link="base_link" />
+        </joint>
+      </xacro:if>
+    </xacro:if>
+
+    <!-- Gazebo requires a base link with inertia: -->
+    <link name="base_link">
+      <inertial>
+        <mass value="0.01" />
+        <origin xyz="0 0 0" />
+        <inertia ixx="1e-7" ixy="0" ixz="0" iyy="1e-7" iyz="0" izz="1e-7" />
+      </inertial>
+    </link>
+    <joint name="base_joint" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="base_link" />
+      <child link="${namespace}_camera_link" />
+    </joint>
+
+    <!-- Include zed xacro: -->
+    <xacro:include filename="$(find zed_wrapper)/urdf/zed_macro.urdf.xacro" />
+    <xacro:zed_camera
+      name="${namespace}"
+      model="${model}"
+      enable_gnss="${enable_gnss}">
+      <origin xyz="${xyz}" rpy="${rpy}" />
+    </xacro:zed_camera>
+
+    <!-- Add gazebo plugin: -->
+    <xacro:if value="${gazebo}">
+      <gazebo reference="${namespace}_${align}_camera_frame">
+
+        <!-- rgb_camera: -->
+        <sensor type="camera" name="zed2i_color">
+          <always_on>true</always_on>
+          <update_rate>30.0</update_rate>
+
+          <topic>${namespace}/color/image_raw</topic>
+          <visualize>false</visualize>
+
+          <gz_frame_id>${namespace}/${namespace}_${align}_camera_optical_frame</gz_frame_id>
+          <camera>
+            <horizontal_fov>${110.0/180.0*pi}</horizontal_fov>
+            <image>
+              <width>640</width>
+              <height>480</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>300.0</far>
+            </clip>
+          </camera>
+        </sensor>
+
+        <!-- depth camera -->
+        <sensor type="depth_camera" name="zed2i_depth">
+          <always_on>true</always_on>
+          <update_rate>30.0</update_rate>
+
+          <topic>${namespace}/depth/image_rect_raw_float</topic>
+          <visualize>false</visualize>
+
+          <gz_frame_id>${namespace}/${namespace}_${align}_camera_optical_frame</gz_frame_id>
+          <camera>
+            <horizontal_fov>${110.0/180.0*pi}</horizontal_fov>
+            <image>
+              <width>640</width>
+              <height>480</height>
+            </image>
+            <clip>
+              <near>0.2</near>
+              <far>65.536</far>
+            </clip>
+          </camera>
+        </sensor>
+
+      </gazebo>
+    </xacro:if>
+  </xacro:macro>
+  <xacro:arg name="namespace" default="realsense" />
+  <xacro:arg name="parent" default="" />
+  <xacro:rcdt_zed2i namespace="$(arg namespace)" parent="$(arg parent)" />
+</robot>

--- a/ros2_ws/src/rcdt_test/rcdt_test/sensors/integration/test_zed.py
+++ b/ros2_ws/src/rcdt_test/rcdt_test/sensors/integration/test_zed.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Alliander N. V.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+import launch_pytest
+import pytest
+from _pytest.fixtures import SubRequest
+from launch import LaunchDescription
+from rcdt_launch.robot import Camera
+from rcdt_utilities.launch_utils import assert_for_message, get_file_path
+from rcdt_utilities.register import Register, RegisteredLaunchDescription
+from rcdt_utilities.test_utils import wait_for_register
+from realsense2_camera_msgs.msg import RGBD
+from sensor_msgs.msg import CameraInfo, Image
+
+namespace = "zed"
+
+
+@launch_pytest.fixture(scope="module")
+def launch(request: SubRequest) -> LaunchDescription:
+    """Fixture to create launch file for the realsense test.
+
+    Args:
+        request (SubRequest): The pytest request object, used to access command line options
+
+    Returns:
+        LaunchDescription: The launch description for the realsense test.
+    """
+    Camera(platform="zed", position=[0, 0, 0.5], namespace=namespace)
+    launch = RegisteredLaunchDescription(
+        get_file_path("rcdt_launch", ["launch"], "robots.launch.py"),
+        launch_arguments={
+            "rviz": "False",
+            "simulation": request.config.getoption("simulation"),
+        },
+    )
+    return Register.connect_context([launch])
+
+
+@pytest.mark.launch(fixture=launch)
+def test_wait_for_register(timeout: int) -> None:
+    """Test that the robot is registered in the system to start the tests.
+
+    Args:
+        timeout (int): The timeout in seconds before stopping the test.
+    """
+    wait_for_register(timeout=timeout)
+
+
+@pytest.mark.launch(fixture=launch)
+def test_color_image_published(timeout: int) -> None:
+    """Test that color images are published.
+
+    Args:
+        timeout (int): The timeout in seconds to wait for the joint states to be published.
+    """
+    assert_for_message(Image, f"/{namespace}/color/image_raw", timeout=timeout)
+
+
+@pytest.mark.launch(fixture=launch)
+def test_color_camera_info_published(timeout: int) -> None:
+    """Test that color camera info is published.
+
+    Args:
+        timeout (int): The timeout in seconds to wait for the joint states to be published.
+    """
+    assert_for_message(CameraInfo, f"/{namespace}/color/camera_info", timeout=timeout)
+
+
+@pytest.mark.launch(fixture=launch)
+def test_depth_image_published(timeout: int) -> None:
+    """Test that depth images are published.
+
+    Args:
+        timeout (int): The timeout in seconds to wait for the joint states to be published.
+    """
+    assert_for_message(Image, f"/{namespace}/depth/image_rect_raw", timeout=timeout)
+
+
+@pytest.mark.launch(fixture=launch)
+def test_depth_camera_info_published(timeout: int) -> None:
+    """Test that color camera info is published.
+
+    Args:
+        timeout (int): The timeout in seconds to wait for the joint states to be published.
+    """
+    assert_for_message(CameraInfo, f"/{namespace}/depth/camera_info", timeout=timeout)
+
+
+@pytest.mark.launch(fixture=launch)
+def test_rgbd_published(timeout: int) -> None:
+    """Test that RGBD messages are published.
+
+    Args:
+        timeout (int): The timeout in seconds to wait for the joint states to be published.
+    """
+    assert_for_message(RGBD, f"/{namespace}/rgbd", timeout=timeout)

--- a/run
+++ b/run
@@ -20,5 +20,7 @@ cp --update=none -a pyflow/default_config/. .config/pyflow
 touch $SCRIPT_DIR/.personal.bashrc
 docker pull $IMAGE:$image_tag
 
+mkdir -p $SCRIPT_DIR/.cache/zed/resources $SCRIPT_DIR/.cache/zed/settings
+
 echo Running $IMAGE:$image_tag ...
 IMAGE_TAG=$image_tag docker compose -f $SCRIPT_DIR/.devcontainer/docker-compose.yml run --rm $SERVICE


### PR DESCRIPTION
## Description

This PR adds the zed2i to the devcontainer for simulation. 

- The settings and resources are all mounted to the .cache so those only needs to be downloaded once.
- UDEV rules need to be installed on the host machine once.

Fixes: #223 

- [x] Works in simulation
- [x] Works with real hardware
- [x] Has a workflow test
- [x] Documented