### PR TITLE
Add EGL vendor library filename to rcdt_robotics environment

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - "RCUTILS_COLORIZED_OUTPUT=1"
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=all
+      - __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/10_nvidia.json
   rcdt_ros2:
     image: rcdt/ros2:${IMAGE_TAG}
     container_name: rcdt_ros2


### PR DESCRIPTION
## Description

When running Gazebo with the Ogre2 rendering engine, I encountered the following error:

MESA: error: ZINK: vkCreateInstance failed (VK_ERROR_INCOMPATIBLE_DRIVER)

This happened because EGL was selecting the Mesa Zink vendor instead of the NVIDIA Vulkan/EGL implementation.
On systems with both Mesa and NVIDIA drivers installed, the default EGL vendor search can pick the wrong vendor file.

Set the __EGL_VENDOR_LIBRARY_FILENAMES environment variable to point directly to the NVIDIA vendor JSON file:
This ensures that EGL loads the NVIDIA driver and bypasses the Zink path.

See where i found the solution: [this issue](https://robotics.stackexchange.com/questions/114967/ignition-gazebo-on-hpc-with-apptainer-ogre2-rendering-issue)  