### PR TITLE
Add dynamics obstacles to global costmap.

### DIFF
--- a/.github/workflows/reusable-workspace.yml
+++ b/.github/workflows/reusable-workspace.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: uv sync
         shell: bash -ieo pipefail {0}
         run: |

--- a/ros2_ws/src/rcdt_panther/config/nav2/amcl.yaml
+++ b/ros2_ws/src/rcdt_panther/config/nav2/amcl.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Based on: https://docs.nav2.org/configuration/packages/configuring-behavior-server.html
+# Based on: https://docs.nav2.org/configuration/packages/configuring-amcl.html
 
 amcl:
   ros__parameters:

--- a/ros2_ws/src/rcdt_panther/config/nav2/amcl.yaml
+++ b/ros2_ws/src/rcdt_panther/config/nav2/amcl.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Alliander N. V.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Based on: https://docs.nav2.org/configuration/packages/configuring-behavior-server.html
+
+amcl:
+  ros__parameters:
+    base_frame_id: "panther/base_footprint"
+    odom_frame_id: "panther/odom"
+    scan_topic: /velodyne/scan
+    first_map_only: true
+    set_initial_pose: true
+    initial_pose:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      yaw: 0.0

--- a/ros2_ws/src/rcdt_panther/config/nav2/global_costmap.yaml
+++ b/ros2_ws/src/rcdt_panther/config/nav2/global_costmap.yaml
@@ -7,7 +7,31 @@
 global_costmap:
   global_costmap:
     ros__parameters:
+      always_send_full_costmap: True
       robot_base_frame: panther/base_footprint
       robot_radius: 0.6
+      plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
+      static_layer:
+        plugin: "nav2_costmap_2d::StaticLayer"
+      obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
+        enabled: True
+        observation_sources: scan
+        footprint_clearing_enabled: true
+        max_obstacle_height: 2.0
+        combination_method: 1
+        scan:
+          topic: /velodyne/scan
+          obstacle_max_range: 5.0
+          obstacle_min_range: 0.0
+          raytrace_max_range: 10.0
+          raytrace_min_range: 0.0
+          max_obstacle_height: 2.0
+          min_obstacle_height: 0.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+          inf_is_valid: false
       inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
         inflation_radius: 0.7

--- a/ros2_ws/src/rcdt_panther/config/nav2/map.png
+++ b/ros2_ws/src/rcdt_panther/config/nav2/map.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:111fcbf631d0b9b04765fa5c7c834b53c4247287a7b81b09038e04d276472d03
+size 341

--- a/ros2_ws/src/rcdt_panther/config/nav2/map.png.license
+++ b/ros2_ws/src/rcdt_panther/config/nav2/map.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Alliander N. V.
+
+SPDX-License-Identifier: Apache-2.0

--- a/ros2_ws/src/rcdt_panther/config/nav2/map.yaml
+++ b/ros2_ws/src/rcdt_panther/config/nav2/map.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Alliander N. V.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Based on: https://docs.ros.org/en/humble/p/nav2_map_server/
+
+image: map.png
+resolution: 0.1
+origin: [-5, -5, 0]
+negate: 0
+occupied_thresh: 0.65
+free_thresh: 0.196

--- a/ros2_ws/src/rcdt_panther/launch/panther.launch.py
+++ b/ros2_ws/src/rcdt_panther/launch/panther.launch.py
@@ -12,9 +12,9 @@ use_sim_arg = LaunchArgument("simulation", True, [True, False])
 load_gazebo_ui_arg = LaunchArgument("load_gazebo_ui", False, [True, False])
 use_rviz_arg = LaunchArgument("rviz", True, [True, False])
 world_arg = LaunchArgument("world", "walls.sdf")
-use_collision_monitor_arg = LaunchArgument("collision_monitor", False, [True, False])
 use_velodyne_arg = LaunchArgument("velodyne", False, [True, False])
 use_slam_arg = LaunchArgument("slam", False, [True, False])
+use_collision_monitor_arg = LaunchArgument("collision_monitor", False, [True, False])
 use_navigation_arg = LaunchArgument("navigation", False, [True, False])
 scale_speed_arg = LaunchArgument(
     "scale_speed", default_value=0.4, min_value=0.0, max_value=1.0
@@ -35,9 +35,9 @@ def launch_setup(context: LaunchContext) -> list:
     load_gazebo_ui = load_gazebo_ui_arg.bool_value(context)
     use_rviz = use_rviz_arg.bool_value(context)
     world = world_arg.string_value(context)
-    use_collision_monitor = use_collision_monitor_arg.bool_value(context)
     use_velodyne = use_velodyne_arg.bool_value(context)
     use_slam = use_slam_arg.bool_value(context)
+    use_collision_monitor = use_collision_monitor_arg.bool_value(context)
     use_navigation = use_navigation_arg.bool_value(context)
     scale_speed = scale_speed_arg.float_value(context)
     panther_xyz = panther_xyz_arg.string_value(context)
@@ -45,10 +45,7 @@ def launch_setup(context: LaunchContext) -> list:
     namespace = "panther"
     ns = f"/{namespace}" if namespace else ""
 
-    if use_navigation:
-        use_slam = True
-
-    if use_slam or use_collision_monitor:
+    if use_slam or use_collision_monitor or use_navigation:
         use_velodyne = True
 
     launch_arguments = {
@@ -119,6 +116,7 @@ def launch_setup(context: LaunchContext) -> list:
         launch_arguments={
             "simulation": str(use_sim),
             "autostart": str(True),
+            "slam": str(use_slam),
             "collision_monitor": str(use_collision_monitor),
             "navigation": str(use_navigation),
         },
@@ -151,7 +149,6 @@ def generate_launch_description() -> LaunchDescription:
             load_gazebo_ui_arg.declaration,
             use_rviz_arg.declaration,
             world_arg.declaration,
-            use_collision_monitor_arg.declaration,
             use_velodyne_arg.declaration,
             use_slam_arg.declaration,
             use_collision_monitor_arg.declaration,

--- a/ros2_ws/src/rcdt_utilities/rviz/panther_navigation_and_collision_monitor.rviz
+++ b/ros2_ws/src/rcdt_utilities/rviz/panther_navigation_and_collision_monitor.rviz
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Alliander N. V.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 Panels:
   - Class: rviz_common/Displays
     Help Height: 78

--- a/ros2_ws/src/rcdt_utilities/rviz/panther_navigation_and_collision_monitor.rviz
+++ b/ros2_ws/src/rcdt_utilities/rviz/panther_navigation_and_collision_monitor.rviz
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: Alliander N. V.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 Panels:
   - Class: rviz_common/Displays
     Help Height: 78
@@ -46,7 +42,7 @@ Visualization Manager:
       Offset:
         X: 0
         Y: 0
-        Z: 0
+        Z: -0.20000000298023224
       Plane: XY
       Plane Cell Count: 10
       Reference Frame: <Fixed Frame>
@@ -333,7 +329,7 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
-      Distance: 7.972400188446045
+      Distance: 11.211273193359375
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1


### PR DESCRIPTION
## Description

This PR adds dynamics obstacles to the global costmap, based on the scan topic. To do this, we:

- add the option to launch without slam, since the objects are otherwise also added to the normal map
- add amcl to replace slam for localization without mapping
- define a map that can be loaded when slam is not used
- add settings to the global costmap to use the scan to define obstacles

Fixes: #242 

## Testing

pass CICD