### PR TITLE
Skip joy gripper tests.

### DIFF
--- a/.github/workflows/reusable-workspace.yml
+++ b/.github/workflows/reusable-workspace.yml
@@ -45,11 +45,6 @@ jobs:
           cd ros2_ws
           source install/setup.bash
           echo "GZ_SIM_RESOURCE_PATH: ${GZ_SIM_RESOURCE_PATH}"
-          for i in {1..10}; do
-            echo "===== Run $i ====="
-            uv run pytest -s \
-              --ignore=src/rcdt_franka/rcdt_franka/test/integration/test_franka_realsense.py \
-              src/rcdt_franka/rcdt_franka/test/end_to_end
-          done
+          uv run pytest -s --ignore=src/rcdt_franka/rcdt_franka/test/integration/test_franka_realsense.py src/
 
 # Ignore src/rcdt_franka/rcdt_franka/test/integration/test_franka_realsense.py due to gpu limitation in CICD.

--- a/.github/workflows/reusable-workspace.yml
+++ b/.github/workflows/reusable-workspace.yml
@@ -45,6 +45,11 @@ jobs:
           cd ros2_ws
           source install/setup.bash
           echo "GZ_SIM_RESOURCE_PATH: ${GZ_SIM_RESOURCE_PATH}"
-          uv run pytest -s --ignore=src/rcdt_franka/rcdt_franka/test/integration/test_franka_realsense.py src/
+          for i in {1..10}; do
+            echo "===== Run $i ====="
+            uv run pytest -s \
+              --ignore=src/rcdt_franka/rcdt_franka/test/integration/test_franka_realsense.py \
+              src/rcdt_franka/rcdt_franka/test/end_to_end
+          done
 
 # Ignore src/rcdt_franka/rcdt_franka/test/integration/test_franka_realsense.py due to gpu limitation in CICD.

--- a/ros2_ws/src/rcdt_franka/rcdt_franka/test/end_to_end/base_franka.py
+++ b/ros2_ws/src/rcdt_franka/rcdt_franka/test/end_to_end/base_franka.py
@@ -67,6 +67,9 @@ def get_tests() -> dict:
             ([1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1], 0.0),
         ],
     )
+    @pytest.mark.skip(
+        reason="This test sometimes failes in CI/CD for unknown reasons. This should be fixed when migrating the joystick node to C++."
+    )
     def test_joy_gripper_node(
         _self: object,
         buttons: list[int],


### PR DESCRIPTION
## Description

For an unknown reason, the joy gripper tests sometimes fail. Since we were not able to find the problem and we have plans to migrate this node to C++ later, we decided to skip this test for now.