### PR TITLE
[hotfix] add mermaid to sphinx requirements.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,4 @@ myst-parser
 sphinx_copybutton
 sphinx_rtd_theme
 sphinxcontrib-video
+sphinxcontrib-mermaid


### PR DESCRIPTION
## Description

Build of the documentation in the pipeline fails, since we forgot to add the sphinx mermaid plugin to the sphinx requirements.