### PR TITLE
Improve stability of tests

### DIFF
--- a/.github/workflows/reusable-workspace.yml
+++ b/.github/workflows/reusable-workspace.yml
@@ -60,7 +60,7 @@ jobs:
             --entrypoint /bin/bash "${{ inputs.container-image }}" -i -c "
               source /home/rcdt/.bashrc &&
               source install/setup.bash &&
-              uv run xvfb-run pytest -s -rsxf src/
+              uv run xvfb-run pytest -s -v -rsxf src/
             "
 
       - name: Show disk usage after job

--- a/ros2_ws/src/rcdt_franka/include/gripper.hpp
+++ b/ros2_ws/src/rcdt_franka/include/gripper.hpp
@@ -33,6 +33,8 @@ class Gripper : public rclcpp::Node {
   rclcpp_action::Client<Move>::SharedPtr client_move;
   /** The action client to grasp with the gripper. */
   rclcpp_action::Client<Grasp>::SharedPtr client_grasp;
+  /** Timeout for future objects in seconds. */
+  int timeout = 5;
 
   /**
    * @brief Handle goal requests

--- a/ros2_ws/src/rcdt_franka/src/gripper.cpp
+++ b/ros2_ws/src/rcdt_franka/src/gripper.cpp
@@ -60,14 +60,14 @@ void Gripper::open(
   goal.width = 0.08;
   goal.speed = 0.03;
   auto future_goal_handle = client_move->async_send_goal(goal);
-  if (future_goal_handle.wait_for(std::chrono::seconds(5)) ==
+  if (future_goal_handle.wait_for(std::chrono::seconds(timeout)) ==
       std::future_status::timeout) {
     RCLCPP_ERROR(this->get_logger(), "Failed to obtain goal_handle. Timeout.");
     return;
   }
 
   auto future_result = client_move->async_get_result(future_goal_handle.get());
-  if (future_result.wait_for(std::chrono::seconds(5)) ==
+  if (future_result.wait_for(std::chrono::seconds(timeout)) ==
       std::future_status::timeout) {
     RCLCPP_ERROR(this->get_logger(), "Failed to obtain result. Timeout.");
     return;
@@ -94,14 +94,14 @@ void Gripper::close(
   goal.force = 100.0;
   goal.speed = 0.03;
   auto future_goal_handle = client_grasp->async_send_goal(goal);
-  if (future_goal_handle.wait_for(std::chrono::seconds(5)) ==
+  if (future_goal_handle.wait_for(std::chrono::seconds(timeout)) ==
       std::future_status::timeout) {
     RCLCPP_ERROR(this->get_logger(), "Failed to obtain goal_handle. Timeout.");
     return;
   }
 
   auto future_result = client_grasp->async_get_result(future_goal_handle.get());
-  if (future_result.wait_for(std::chrono::seconds(5)) ==
+  if (future_result.wait_for(std::chrono::seconds(timeout)) ==
       std::future_status::timeout) {
     RCLCPP_ERROR(this->get_logger(), "Failed to obtain result. Timeout.");
     return;

--- a/ros2_ws/src/rcdt_panther/src_py/nav2_manager.py
+++ b/ros2_ws/src/rcdt_panther/src_py/nav2_manager.py
@@ -37,6 +37,7 @@ class Nav2Manager(Node):
         Args:
             msg (PoseStamped): The received PoseStamped message.
         """
+        self.get_logger().info("Received new goal pose for navigation.")
         self.basic_navigator.goToPose(msg)
 
     def cb_waypoints(self, msg: Path) -> None:
@@ -45,6 +46,7 @@ class Nav2Manager(Node):
         Args:
             msg (Path): The received Path message.
         """
+        self.get_logger().info("Received new waypoints for navigation.")
         self.basic_navigator.followWaypoints(msg.poses)
 
     def cb_gps_waypoints(self, msg: GeoPath) -> None:
@@ -53,6 +55,7 @@ class Nav2Manager(Node):
         Args:
             msg (GeoPath): The received GeoPath message.
         """
+        self.get_logger().info("Received new GPS waypoints for navigation.")
         geo_poses = []
         for geo_pose_stamped in msg.poses:
             geo_pose_stamped: GeoPoseStamped


### PR DESCRIPTION
## Description

This PR improves the test  stability by the following changes:
- Introduced a `wait_for_nodes_to_stop` fixture, that wait for nodes from a previous tests to stop before continuing. 
- Pass half of the maximum timeout time to the tests, so that we can stop loops before the overall pytest timeout triggers.
- Relax navigation tolerances, since they were not always met.
- Break loops in nav2 tests on timeout.
- Add more information to assert failure messages.

## Testing

CICD