### PR TITLE
[Hotfix] Workflow detect_changes not working correctly.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -372,6 +372,7 @@ jobs:
   linting:
     runs-on: ubuntu-24.04
     needs: [build-ubuntu-images, build-cuda-images]
+    if: always()
     steps:
       - uses: actions/checkout@v4
       - name: Set up python3


### PR DESCRIPTION
## Description
This PR fixes the bug `detect-changes` fails if `${{ github.base_ref }}` is not populated, i.e. when doing a commit to main. 
Furthermore, it only builds the alliander_core image if there are changes to alliander_core.Dockerfile. If there are changes to alliander_description/interfaces/utilities, it will build all images EXCEPT alliander_core/cuda.

Fixes: #387 

## Testing

Explain how you tested your changes.

## Documentation

- [ ] I have updated the documentation (if necessary)

## Additional Notes

Any relevant screenshots, logs, or context.