### PR TITLE
377-monitor-and-control-from-inside-office

### DIFF
--- a/alliander_core/src/alliander_utilities/alliander_utilities/config_objects.py
+++ b/alliander_core/src/alliander_utilities/alliander_utilities/config_objects.py
@@ -359,9 +359,11 @@ class VisualizationConfig(Config):
     Attributes:
         rviz (bool): Whether to enable RViz visualization.
         vizanti (bool): Whether to enable Vizanti visualization.
+        rosboard (bool): Whether to enable ROSBoard visualization.
         gui (bool): Whether to enable GUI.
     """
 
     rviz: bool = True
     vizanti: bool = False
+    rosboard: bool = False
     gui: bool = False

--- a/alliander_visualization/alliander_visualization.Dockerfile
+++ b/alliander_visualization/alliander_visualization.Dockerfile
@@ -28,6 +28,9 @@ RUN apt update \
   && rosdep update --rosdistro $ROS_DISTRO \
   && rosdep install --from-paths src -y -i
 
+# Get rosboard:
+RUN git clone https://github.com/alliander-opensource/rosboard.git src/rosboard
+
 # Get vendor descriptions
 COPY common/get_vendor_descriptions.sh /$WORKDIR/get_vendor_descriptions.sh
 RUN /$WORKDIR/get_vendor_descriptions.sh && rm /$WORKDIR/get_vendor_descriptions.sh

--- a/alliander_visualization/src/alliander_visualization/launch/visualization.launch.py
+++ b/alliander_visualization/src/alliander_visualization/launch/visualization.launch.py
@@ -39,6 +39,8 @@ def launch_setup(context: LaunchContext) -> list:
         get_file_path("alliander_visualization", ["launch"], "vizanti.launch.py")
     )
 
+    rosboard = Node(package="rosboard", executable="rosboard_node")
+
     gui = Node(
         package="alliander_visualization",
         executable="alliander_gui.py",
@@ -49,6 +51,7 @@ def launch_setup(context: LaunchContext) -> list:
         SetParameter(name="use_sim_time", value=simulation),
         Register.group(rviz, context) if config.rviz else SKIP,
         Register.group(vizanti, context) if config.vizanti else SKIP,
+        Register.on_start(rosboard, context) if config.rosboard else SKIP,
         Register.on_start(gui, context) if config.gui else SKIP,
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ alliander-nav2 = [
 alliander-visualization = [
     "nicegui>=3.7.0",
     "numpy>=2.4.1",
+    "simplejpeg>=1.9.0",
+    "tornado>=6.5.4",
 ]
 ros = [
     "catkin-pkg>=1.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -107,6 +107,8 @@ alliander-nav2 = [
 alliander-visualization = [
     { name = "nicegui" },
     { name = "numpy" },
+    { name = "simplejpeg" },
+    { name = "tornado" },
 ]
 documentation = [
     { name = "myst-parser" },
@@ -158,6 +160,8 @@ alliander-nav2 = [
 alliander-visualization = [
     { name = "nicegui", specifier = ">=3.7.0" },
     { name = "numpy", specifier = ">=2.4.1" },
+    { name = "simplejpeg", specifier = ">=1.9.0" },
+    { name = "tornado", specifier = ">=6.5.4" },
 ]
 documentation = [
     { name = "myst-parser", specifier = ">=5.0.0" },
@@ -1139,6 +1143,23 @@ wheels = [
 ]
 
 [[package]]
+name = "simplejpeg"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/64/da60f0ba80570f9a36c9b6e055f4364bda2c547715296d5773d2ea6d5a60/simplejpeg-1.9.0.tar.gz", hash = "sha256:5ac7d9489eeb812c2e7ea5c283994a29d9fefdfe5ed7b86c09d485e0dd366689", size = 3965764, upload-time = "2025-10-10T10:58:08.197Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/05/a932dc6a89cdfd8cdfbd300340d87164eb3daaaf6a1b86b09bf0b87e0c2a/simplejpeg-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f218b4810f0dcb573bf323dae73177961c235c79588657927d7893a714636ca2", size = 424657, upload-time = "2025-10-10T10:57:36.676Z" },
+    { url = "https://files.pythonhosted.org/packages/44/73/53f7d2e0ce86c9b850301c1c9165dedbac9ac88a6045aa1cb8ad37176c17/simplejpeg-1.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f987b5783e0d649457acf136a4544a75f6d40f15cba89b6c5a4583ccf5577957", size = 401461, upload-time = "2025-10-10T10:57:37.963Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c1/0cbf167e3efa32adfbb0674a3504eb118cc5bdc372a44ee937c30324188e/simplejpeg-1.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:08ab337ca3b26d7562f5ad686ab8f3966fb206fced607d248e693cbc57fc53b3", size = 448908, upload-time = "2025-10-10T10:57:39.303Z" },
+    { url = "https://files.pythonhosted.org/packages/03/80/44514f83a09500d1eb8ebba8cadd9aa16f7a60690c19dbd98a570ca2c0ec/simplejpeg-1.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5be1c8932f43f99b6cc52f8ac4c28e3ac19a1a830351efdb159715fd683e2053", size = 407547, upload-time = "2025-10-10T10:57:40.867Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d7/115be2e87257c1e148c0f911c020c6442eafb8d164cbd642327d21f22179/simplejpeg-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:808b6840f1c6d4de20ae7a086cf9bf49eccac6ef6658df34b4948e071cbe9680", size = 293810, upload-time = "2025-10-10T10:57:42.498Z" },
+    { url = "https://files.pythonhosted.org/packages/49/21/6a4c1589fbcde51a349ef7a629af5867701011bced774389a4f6782ef6cd/simplejpeg-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:b65fdde80097cb1fad9c6dad6a12767215c311704f7fad321fbd8501219fad06", size = 253182, upload-time = "2025-10-10T10:57:44.051Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1339,6 +1360,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
+]
+
+[[package]]
+name = "tornado"
+version = "6.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/1d/0a336abf618272d53f62ebe274f712e213f5a03c0b2339575430b8362ef2/tornado-6.5.4.tar.gz", hash = "sha256:a22fa9047405d03260b483980635f0b041989d8bcc9a313f8fe18b411d84b1d7", size = 513632, upload-time = "2025-12-15T19:21:03.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/a9/e94a9d5224107d7ce3cc1fab8d5dc97f5ea351ccc6322ee4fb661da94e35/tornado-6.5.4-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d6241c1a16b1c9e4cc28148b1cda97dd1c6cb4fb7068ac1bedc610768dff0ba9", size = 443909, upload-time = "2025-12-15T19:20:48.382Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7e/f7b8d8c4453f305a51f80dbb49014257bb7d28ccb4bbb8dd328ea995ecad/tornado-6.5.4-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2d50f63dda1d2cac3ae1fa23d254e16b5e38153758470e9956cbc3d813d40843", size = 442163, upload-time = "2025-12-15T19:20:49.791Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b5/206f82d51e1bfa940ba366a8d2f83904b15942c45a78dd978b599870ab44/tornado-6.5.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1cf66105dc6acb5af613c054955b8137e34a03698aa53272dbda4afe252be17", size = 445746, upload-time = "2025-12-15T19:20:51.491Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/9d/1a3338e0bd30ada6ad4356c13a0a6c35fbc859063fa7eddb309183364ac1/tornado-6.5.4-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:50ff0a58b0dc97939d29da29cd624da010e7f804746621c78d14b80238669335", size = 445083, upload-time = "2025-12-15T19:20:52.778Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d4/e51d52047e7eb9a582da59f32125d17c0482d065afd5d3bc435ff2120dc5/tornado-6.5.4-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5fb5e04efa54cf0baabdd10061eb4148e0be137166146fff835745f59ab9f7f", size = 445315, upload-time = "2025-12-15T19:20:53.996Z" },
+    { url = "https://files.pythonhosted.org/packages/27/07/2273972f69ca63dbc139694a3fc4684edec3ea3f9efabf77ed32483b875c/tornado-6.5.4-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9c86b1643b33a4cd415f8d0fe53045f913bf07b4a3ef646b735a6a86047dda84", size = 446003, upload-time = "2025-12-15T19:20:56.101Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/83/41c52e47502bf7260044413b6770d1a48dda2f0246f95ee1384a3cd9c44a/tornado-6.5.4-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:6eb82872335a53dd063a4f10917b3efd28270b56a33db69009606a0312660a6f", size = 445412, upload-time = "2025-12-15T19:20:57.398Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c7/bc96917f06cbee182d44735d4ecde9c432e25b84f4c2086143013e7b9e52/tornado-6.5.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6076d5dda368c9328ff41ab5d9dd3608e695e8225d1cd0fd1e006f05da3635a8", size = 445392, upload-time = "2025-12-15T19:20:58.692Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/1a/d7592328d037d36f2d2462f4bc1fbb383eec9278bc786c1b111cbbd44cfa/tornado-6.5.4-cp39-abi3-win32.whl", hash = "sha256:1768110f2411d5cd281bac0a090f707223ce77fd110424361092859e089b38d1", size = 446481, upload-time = "2025-12-15T19:21:00.008Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/6d/c69be695a0a64fd37a97db12355a035a6d90f79067a3cf936ec2b1dc38cd/tornado-6.5.4-cp39-abi3-win_amd64.whl", hash = "sha256:fa07d31e0cd85c60713f2b995da613588aa03e1303d75705dca6af8babc18ddc", size = 446886, upload-time = "2025-12-15T19:21:01.287Z" },
+    { url = "https://files.pythonhosted.org/packages/50/49/8dc3fd90902f70084bd2cd059d576ddb4f8bb44c2c7c0e33a11422acb17e/tornado-6.5.4-cp39-abi3-win_arm64.whl", hash = "sha256:053e6e16701eb6cbe641f308f4c1a9541f91b6261991160391bfc342e8a551a1", size = 445910, upload-time = "2025-12-15T19:21:02.571Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

We want to be sure that we can see what the robot sees. 
Fixes: #377 

First tried to use Foxglove, but this did not work properly, probably due to the lack of compression. For more information, see #395 .

This PR integrates Rosboard. A fork was made with a tiny adaption to support new versions of Numpy. Rosboard does not support input, so no joystick, no waypoints and no E-stop control. These control inputs should still be done using Vizanti, our rcdt_gui or a ROS service call via SHH. 

To start Rosboard, set `self.viz_conf.rosboard = True` for a desired configuration in `predefined_configurations.py`.

## Issue:

### DoD
- [x] Put new SIM card in Lynx
- [x] We want to be able to see the camera
- [x] See GPS location
- [x] Install Rosboard or Foxglove
- [ ] Provide waypoints
- [ ] Be able to use E-stop from our GUI
- [x] Test how far the robot can go without losing connection; until the entry port of the office grounds
- [ ] Update documentation

Nice to have
- [ ] Pointcloud data

## Testing

Drove around the building with the Panther, with sim card connection for internet. 
Rosboard was running on a laptop inside the office, over a Tailscale connection.
Rosboard was able to visualize GPS location (/gps/fix). 

Camera was not testable on the Panther yet, because of #383.
Realsense was tested with two laptops on different networks via Tailscale, without problems.

Pointcloud was tested on Panther (inside) with Tailscale, but this was too much and crashed the Rosboard connection. Scan was also tested on Panther (inside) with Tailscale, this seemed to work.

## Documentation

- [ ] I have updated the documentation (if necessary)

## Additional Notes

Any relevant screenshots, logs, or context.