### PR TITLE
[Hotfix] Build and use branch tagged images when alliander_core is changed.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -169,6 +169,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ env.BRANCH_NAME }}
       - name: Set up python3
         uses: actions/setup-python@v6
         with:

--- a/image_manager.py
+++ b/image_manager.py
@@ -63,7 +63,11 @@ class ImageManager:
         changed_packages = utils.get_changed_packages()
         for repository in self.selected:
             package = f"alliander_{repository}"
-            tag = utils.get_git_branch() if package in changed_packages else "latest"
+            tag = (
+                "latest"
+                if set({package, "alliander_core"}).isdisjoint(changed_packages)
+                else utils.get_git_branch()
+            )
             tag = "latest" if tag == "main" else tag
             if pull:
                 self.run_pull_subprocess(repository, tag)

--- a/start.py
+++ b/start.py
@@ -241,7 +241,10 @@ class Compose:
 
         # Use the branch tag if the package has changes:
         name_branch = subprocess.getoutput("git rev-parse --abbrev-ref HEAD")
-        if package in self.changed_packages and name_branch != "main":
+        if (
+            not set({package, "alliander_core"}).isdisjoint(self.changed_packages)
+            and name_branch != "main"
+        ):
             service["image"] += f":{name_branch}"
 
         if self.mode == "configuration-no-nvidia":


### PR DESCRIPTION
## Description

We only used branch tagged images when the particular package was changed.
However, changes in `alliander_core` affect all other packages, and should therefore also result in the build and use of a branch tagged image.

This PR fixes that problem.