### PR TITLE
Adjust trajectory line visualization

### DIFF
--- a/alliander_visualization/src/alliander_visualization/alliander_visualization/rviz.py
+++ b/alliander_visualization/src/alliander_visualization/alliander_visualization/rviz.py
@@ -161,11 +161,11 @@ class Rviz:  # noqa PLR0904
                 "Name": topic,
                 "Topic": {"Value": topic},
                 "Pose Style": "Arrows",
-                "Pose Color": "255; 85; 255",
-                "Shaft Length": 0.3,
-                "Head Length": 0.2,
-                "Shaft Diameter": 0.05,
-                "Head Diameter": 0.1,
+                "Pose Color": "255; 225; 0",
+                "Shaft Length": 0.05,
+                "Head Length": 0.01,
+                "Shaft Diameter": 0.015,
+                "Head Diameter": 0.015,
             }
         )
 


### PR DESCRIPTION
## Description

Slightly changed the design of the trajectory line.
From a very present line made of big pink arrows to a thin line of tiny yellow arrows.

Original:
<img width="534" height="448" alt="Screenshot from 2026-05-01 15-00-40" src="https://github.com/user-attachments/assets/7f714631-bb23-49f3-9854-e8f8e5321318" />

New design:
<img width="728" height="541" alt="Screenshot from 2026-05-04 15-01-00" src="https://github.com/user-attachments/assets/10d8e01e-3bc0-4cd9-950d-8687fbea9dc2" />