### PR TITLE
Hotfix for current Slam Toolbox implementation

### DIFF
--- a/alliander_robotics/alliander_nav2/src/alliander_nav2/config/slam_params.yaml
+++ b/alliander_robotics/alliander_nav2/src/alliander_nav2/config/slam_params.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Alliander N. V.
 #
 # SPDX-License-Identifier: Apache-2.0
+# 
+# Based on: https://github.com/SteveMacenski/slam_toolbox/blob/ros2/config/mapper_params_localization.yaml
 
 slam_toolbox:
   ros__parameters:

--- a/alliander_robotics/alliander_nav2/src/alliander_nav2/launch/nav2.launch.py
+++ b/alliander_robotics/alliander_nav2/src/alliander_nav2/launch/nav2.launch.py
@@ -49,6 +49,7 @@ def launch_setup(context: LaunchContext) -> list:  # noqa: PLR0912, PLR0915
     # Define configuration:
     lifecycle_nodes_names = []
     use_map_localization = True
+    use_slam_map_localization = False
     plugins = ["static_layer", "obstacle_layer", "inflation_layer"]
 
     if nav2.collision_monitor:
@@ -56,6 +57,7 @@ def launch_setup(context: LaunchContext) -> list:  # noqa: PLR0912, PLR0915
     if nav2.slam:
         lifecycle_nodes_names.append("slam_toolbox")
         use_map_localization = False
+        use_slam_map_localization = True
     if nav2.gps:
         if not namespace_gps:
             raise ValueError("Namespace for GPS must be provided when using GPS.")
@@ -68,7 +70,7 @@ def launch_setup(context: LaunchContext) -> list:  # noqa: PLR0912, PLR0915
                     "amcl",
                 ]
             )
-        else:
+        elif not use_slam_map_localization:
             plugins.remove("static_layer")
         lifecycle_nodes_names.extend(
             [
@@ -124,7 +126,7 @@ def launch_setup(context: LaunchContext) -> list:  # noqa: PLR0912, PLR0915
         {
             "global_frame": f"{namespace_vehicle}/odom",
             "robot_base_frame": f"{namespace_vehicle}/base_footprint",
-            "rolling_window": nav2.gps,
+            "rolling_window": (nav2.gps or nav2.slam),
             "width": 10,
             "height": 10,
             "plugins": plugins,

--- a/alliander_robotics/alliander_nav2/src/alliander_nav2/launch/nav2.launch.py
+++ b/alliander_robotics/alliander_nav2/src/alliander_nav2/launch/nav2.launch.py
@@ -49,7 +49,6 @@ def launch_setup(context: LaunchContext) -> list:  # noqa: PLR0912, PLR0915
     # Define configuration:
     lifecycle_nodes_names = []
     use_map_localization = True
-    use_slam_map_localization = False
     plugins = ["static_layer", "obstacle_layer", "inflation_layer"]
 
     if nav2.collision_monitor:
@@ -57,7 +56,6 @@ def launch_setup(context: LaunchContext) -> list:  # noqa: PLR0912, PLR0915
     if nav2.slam:
         lifecycle_nodes_names.append("slam_toolbox")
         use_map_localization = False
-        use_slam_map_localization = True
     if nav2.gps:
         if not namespace_gps:
             raise ValueError("Namespace for GPS must be provided when using GPS.")
@@ -70,7 +68,7 @@ def launch_setup(context: LaunchContext) -> list:  # noqa: PLR0912, PLR0915
                     "amcl",
                 ]
             )
-        elif not use_slam_map_localization:
+        elif not nav2.slam:
             plugins.remove("static_layer")
         lifecycle_nodes_names.extend(
             [

--- a/alliander_robotics/predefined_configurations.py
+++ b/alliander_robotics/predefined_configurations.py
@@ -242,6 +242,8 @@ class PredefinedConfigurations:
     def config_panther_slam(self) -> None:  # noqa: D102
         vehicle = Vehicle("panther", (0, 0, 0.2))
         vehicle.nav2_config.slam = True
+        vehicle.nav2_config.navigation = True
+        vehicle.nav2_config.window_size = 20
         lidar = Lidar(
             "velodyne",
             position=(0.125, 0.185, 0.20),
@@ -251,6 +253,7 @@ class PredefinedConfigurations:
 
         link(vehicle, lidar)
         self.plat_conf.platforms = [vehicle, lidar]
+        self.sim_conf.world = "walls.sdf"
 
     @register_configuration("panther_lidar_navigation")
     def config_panther_lidar_navigation(self) -> None:  # noqa: D102


### PR DESCRIPTION
## Description

The `panther_slam` configuration did not work anymore. This hotfix adjusts some parameters such that the SLAM configuration works again.

The `static_layer` plugin was still required for SLAM to work.


<img width="957" height="702" alt="Screenshot from 2026-05-11 11-22-10" src="https://github.com/user-attachments/assets/b46d92a4-92c2-48bf-a076-302fe6bccf8c" />

<img width="957" height="702" alt="Screenshot from 2026-05-11 11-22-49" src="https://github.com/user-attachments/assets/d347e21d-df1b-4942-b91f-e0a0cd4cc7fd" />

<img width="957" height="702" alt="Screenshot from 2026-05-11 11-23-51" src="https://github.com/user-attachments/assets/f62a6c9d-da73-4965-818a-4b6b74bdcc07" />
