### PR TITLE
ouster follows ROS time now

### DIFF
--- a/alliander_robotics/alliander_ouster/src/alliander_ouster/launch/hardware.launch.py
+++ b/alliander_robotics/alliander_ouster/src/alliander_ouster/launch/hardware.launch.py
@@ -40,6 +40,7 @@ def launch_setup(context: LaunchContext) -> list:
                 "lidar_port": 7502,
                 "imu_port": 7503,
                 "lidar_mode": "1024x10",  # options: { 512x10, 512x20, 1024x10, 1024x20, 2048x10, 4096x5 }
+                "timestamp_mode": "TIME_FROM_ROS_TIME",
                 "sensor_frame": sensor_frame,
                 "lidar_frame": lidar_frame,
                 "imu_frame": imu_frame,

--- a/alliander_robotics/alliander_ouster/src/alliander_ouster/launch/ouster.launch.py
+++ b/alliander_robotics/alliander_ouster/src/alliander_ouster/launch/ouster.launch.py
@@ -9,7 +9,7 @@ from alliander_utilities.register import Register, RegisteredLaunchDescription
 from alliander_utilities.ros_utils import get_file_path
 from launch import LaunchContext, LaunchDescription
 from launch.actions import OpaqueFunction
-from launch_ros.actions import Node
+from launch_ros.actions import Node, SetParameter
 
 platform_arg = LaunchArgument("platform_config", "")
 
@@ -66,6 +66,7 @@ def launch_setup(context: LaunchContext) -> list:
     )
 
     return [
+        SetParameter(name="use_sim_time", value=lidar_config.simulation),
         Register.on_start(state_publisher, context),
         Register.on_start(static_tf, context),
         Register.group(hardware, context) if not lidar_config.simulation else SKIP,

--- a/alliander_robotics/predefined_configurations.py
+++ b/alliander_robotics/predefined_configurations.py
@@ -329,6 +329,7 @@ class PredefinedConfigurations:
     def config_lynx_lidar_navigation(self) -> None:  # noqa: D102
         vehicle = Vehicle("lynx", (0, 0, 0.2))
         vehicle.nav2_config.navigation = True
+        vehicle.nav2_config.controller = "mppi"
         lidar = Lidar("ouster", (0.06, 0.0, 0.25))
         imu = IMU("xsens", position=(-0.28, 0.04, 0.25), orientation=(0, 0, 180))
 
@@ -378,3 +379,19 @@ class PredefinedConfigurations:
         vehicle = Vehicle("panther", (0, -0.5, 0.2))
         arm = Arm("franka", (0, 0.5, 0))
         self.plat_conf.platforms = [vehicle, arm]
+
+    # Demos
+    @register_configuration("lynx_indoor_demo")
+    def config_lynx_indoor_demo(self) -> None:  # noqa: D102
+        vehicle = Vehicle("lynx", (0, 0, 0.2))
+        vehicle.nav2_config.navigation = True
+        vehicle.nav2_config.controller = "mppi"
+        lidar = Lidar("ouster", (0.06, 0.0, 0.25))
+        imu = IMU("xsens", position=(-0.28, 0.04, 0.25), orientation=(0, 0, 180))
+        camera = Camera("realsense", (0.30, 0, 0.18))
+
+        link(vehicle, lidar)
+        link(vehicle, imu)
+        link(vehicle, camera)
+        self.plat_conf.platforms = [vehicle, lidar, imu, camera]
+        self.sim_conf.world = "walls.sdf"


### PR DESCRIPTION
## Description

Ouster normally uses an internal timestamp (seconds from boot) for messages, causing issues with other parts of ROS. This PR makes Ouster follow ROS time.

## Testing

Explain how you tested your changes.

## Documentation

- [x] I have updated the documentation (if necessary)

## Additional Notes

Any relevant screenshots, logs, or context.