### PR TITLE
Switch to the new 'managed-linux' group, since the 'managed' group wil be removed.

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,7 +20,7 @@ jobs:
   # Based on: https://www.sphinx-doc.org/en/master/tutorial/deploying.html#
   build:
     runs-on:
-      group: managed
+      group: managed-linux
     permissions:
       contents: write
     steps:
@@ -40,7 +40,7 @@ jobs:
   deploy:
     needs: build
     runs-on:
-      group: managed
+      group: managed-linux
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   select-components:
     runs-on:
-      group: managed
+      group: managed-linux
     outputs:
       UBUNTU_COMPONENTS: ${{ steps.variables.outputs.UBUNTU_COMPONENTS }}
       CUDA_COMPONENTS: ${{ steps.variables.outputs.CUDA_COMPONENTS }}
@@ -53,7 +53,7 @@ jobs:
   build-ubuntu-manifest:
     needs: build-ubuntu
     runs-on:
-      group: managed
+      group: managed-linux
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -91,7 +91,7 @@ jobs:
   build-ubuntu-images-manifest:
     needs: [select-components, build-ubuntu-images]
     runs-on:
-      group: managed
+      group: managed-linux
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -127,7 +127,7 @@ jobs:
   build-cuda-manifest:
     needs: build-cuda
     runs-on:
-      group: managed
+      group: managed-linux
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -165,7 +165,7 @@ jobs:
   build-cuda-images-manifest:
     needs: [select-components, build-cuda-images]
     runs-on:
-      group: managed
+      group: managed-linux
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -179,7 +179,7 @@ jobs:
 
   linting:
     runs-on:
-      group: managed
+      group: managed-linux
     needs: [build-ubuntu-images, build-ubuntu-images-manifest, build-cuda-images, build-cuda-images-manifest]
     if: ${{ !failure() && !cancelled() }}
     steps:

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   remove-branch-images:
     runs-on:
-      group: managed
+      group: managed-linux
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   select-components:
     runs-on:
-      group: managed
+      group: managed-linux
     outputs:
       REBUILD_CORE: ${{ steps.variables.outputs.REBUILD_CORE }}
       UBUNTU_COMPONENTS: ${{ steps.variables.outputs.UBUNTU_COMPONENTS }}
@@ -63,7 +63,7 @@ jobs:
   build-ubuntu-manifest:
     needs: build-ubuntu
     runs-on:
-      group: managed
+      group: managed-linux
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -106,7 +106,7 @@ jobs:
     needs: [select-components, build-ubuntu-images]
     if: ${{ !failure() && !cancelled() && needs.select-components.outputs.REBUILD_UBUNTU_IMAGES == 'true' }}
     runs-on:
-      group: managed
+      group: managed-linux
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -146,7 +146,7 @@ jobs:
   build-cuda-manifest:
     needs: build-cuda
     runs-on:
-      group: managed
+      group: managed-linux
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -189,7 +189,7 @@ jobs:
     needs: [select-components, build-cuda-images]
     if: ${{ !failure() && !cancelled() && needs.select-components.outputs.REBUILD_CUDA_IMAGES == 'true' }}
     runs-on:
-      group: managed
+      group: managed-linux
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -212,7 +212,7 @@ jobs:
       ]
     if: ${{ !failure() && !cancelled() }}
     runs-on:
-      group: managed
+      group: managed-linux
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Description

With the new Alpha release of OSPO runners, we need to switch form 'managed' to 'managed-linux' group.